### PR TITLE
Add method to ensure that hpoa annos are converted to Mondo first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ src/ontology/components/legal_diseases.txt
 src/ontology/components/d2p_*.ttl
 src/ontology/components/disease_to_phenotype_merged_signature.tsv
 src/ontology/components/efo-rename.tsv
+src/ontology/components/mondo-rename.tsv

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -148,6 +148,9 @@ components/d2p_%.ttl: mirror/%.owl
 
 components/efo-rename.tsv: components/mondo_efo_mappings.tsv components/disease_to_phenotype_merged_signature.tsv
 	python3 ../scripts/rename_tsv_subset.py $^ $@
+	
+components/mondo-rename.tsv: mirror/mondo.owl
+	$(ROBOT) query -i $< -q $(SPARQLDIR)/mondo_rename.sparql $@
 
 # If you change the relation in the sparql query, make sure you add the new relation here as well.
 components/legal_diseases.txt: $(SRC) components/disease_to_phenotype_merged.owl
@@ -164,8 +167,9 @@ components/disease_to_phenotype_merged.owl: $(D2P_RAW)
 	$(ROBOT) merge $(addprefix -i , $(D2P_RAW)) \
 		annotate --ontology-iri "http://www.ebi.ac.uk/efo/$@" -o $@
 
-components/disease_to_phenotype.owl: components/disease_to_phenotype_merged.owl  components/efo-rename.tsv components/legal_diseases.txt
+components/disease_to_phenotype.owl: components/disease_to_phenotype_merged.owl components/mondo-rename.tsv components/efo-rename.tsv components/legal_diseases.txt
 	$(ROBOT) merge -i $< \
+		rename --mappings components/mondo-rename.tsv \
 		rename --mappings components/efo-rename.tsv \
 		remove -T components/legal_diseases.txt --select complement --trim true \
 		query --update $(SPARQLDIR)/remove-stray-classes.ru \

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -151,6 +151,7 @@ components/efo-rename.tsv: components/mondo_efo_mappings.tsv components/disease_
 	
 components/mondo-rename.tsv: mirror/mondo.owl
 	$(ROBOT) query -i $< -q $(SPARQLDIR)/mondo_rename.sparql $@
+	cat $@ | tr -d '<>,' > $@.tmp && mv $@.tmp $@
 
 # If you change the relation in the sparql query, make sure you add the new relation here as well.
 components/legal_diseases.txt: $(SRC) components/disease_to_phenotype_merged.owl

--- a/src/sparql/mondo_rename.sparql
+++ b/src/sparql/mondo_rename.sparql
@@ -1,0 +1,17 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX dbpedia2: <http://dbpedia.org/property/>
+PREFIX dbpedia: <http://dbpedia.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?source ?mondo
+WHERE {
+  { ?mondo skos:exactMatch ?source . }
+  FILTER(isIRI(?mondo) && (regex(str(?mondo), "http://purl.obolibrary.org/obo/MONDO_")))
+}


### PR DESCRIPTION
This process takes the hpoa annotations, converts them to Mondo, before they are converted to efo.

@zoependlington we need to sort this before the next efo release I think. This is the problem:

1) Source comes in with lots of links (phenotypes) to OMIM terms.
2) we can either chose to translate those to Mondo (this PR), before translating them to EFO.
3) But this will only work if there is _no_ OMIM / Orphanet at all in EFO (else the annotations to these would be overwritten by Mondo associations, and then subsequently lost).

Can we expect that all diseases in EFO are either Mondo or EFO? 