### PR TITLE
Import OBA, CHEBI, and UBERON terms for kidney and mineral measurements

### DIFF
--- a/src/ontology/imports/chebi_terms.txt
+++ b/src/ontology/imports/chebi_terms.txt
@@ -596,6 +596,7 @@ http://purl.obolibrary.org/obo/CHEBI_27266
 http://purl.obolibrary.org/obo/CHEBI_27300
 http://purl.obolibrary.org/obo/CHEBI_27345
 http://purl.obolibrary.org/obo/CHEBI_27363
+http://purl.obolibrary.org/obo/CHEBI_27365
 http://purl.obolibrary.org/obo/CHEBI_27385
 http://purl.obolibrary.org/obo/CHEBI_27386
 http://purl.obolibrary.org/obo/CHEBI_27389
@@ -1187,6 +1188,7 @@ http://purl.obolibrary.org/obo/CHEBI_46548
 http://purl.obolibrary.org/obo/CHEBI_4657
 http://purl.obolibrary.org/obo/CHEBI_4659
 http://purl.obolibrary.org/obo/CHEBI_46661
+http://purl.obolibrary.org/obo/CHEBI_46662
 http://purl.obolibrary.org/obo/CHEBI_4676
 http://purl.obolibrary.org/obo/CHEBI_46793
 http://purl.obolibrary.org/obo/CHEBI_46819

--- a/src/ontology/imports/oba_terms.txt
+++ b/src/ontology/imports/oba_terms.txt
@@ -17541,6 +17541,12 @@ http://purl.obolibrary.org/obo/OBA_2090000
 http://purl.obolibrary.org/obo/OBA_2090001
 http://purl.obolibrary.org/obo/OBA_2090002
 http://purl.obolibrary.org/obo/OBA_2090003
+http://purl.obolibrary.org/obo/OBA_2090004
+http://purl.obolibrary.org/obo/OBA_2100001
+http://purl.obolibrary.org/obo/OBA_2100002
+http://purl.obolibrary.org/obo/OBA_2100003
+http://purl.obolibrary.org/obo/OBA_2100004
+http://purl.obolibrary.org/obo/OBA_2100005
 http://purl.obolibrary.org/obo/OBA_VT0000012
 http://purl.obolibrary.org/obo/OBA_VT0000047
 http://purl.obolibrary.org/obo/OBA_VT0000056
@@ -24679,4 +24685,3 @@ http://purl.obolibrary.org/obo/UBERON_0035818
 http://purl.obolibrary.org/obo/UBERON_0035933
 http://purl.obolibrary.org/obo/UBERON_0037094
 http://purl.obolibrary.org/obo/UBERON_0037144
-RO:0000052

--- a/src/ontology/imports/uberon_terms.txt
+++ b/src/ontology/imports/uberon_terms.txt
@@ -830,6 +830,7 @@ http://purl.obolibrary.org/obo/UBERON_0006074
 http://purl.obolibrary.org/obo/UBERON_0006082
 http://purl.obolibrary.org/obo/UBERON_0006083
 http://purl.obolibrary.org/obo/UBERON_0006088
+http://purl.obolibrary.org/obo/UBERON_0006171
 http://purl.obolibrary.org/obo/UBERON_0006222
 http://purl.obolibrary.org/obo/UBERON_0006238
 http://purl.obolibrary.org/obo/UBERON_0006240
@@ -1043,6 +1044,7 @@ http://purl.obolibrary.org/obo/UBERON_0036268
 http://purl.obolibrary.org/obo/UBERON_0036269
 http://purl.obolibrary.org/obo/UBERON_0036295
 http://purl.obolibrary.org/obo/UBERON_0036301
+http://purl.obolibrary.org/obo/UBERON_1200002
 http://purl.obolibrary.org/obo/UBERON_2000033
 http://purl.obolibrary.org/obo/UBERON_2000040
 http://purl.obolibrary.org/obo/UBERON_2000058

--- a/src/ontology/iri_dependencies/chebi_terms.txt
+++ b/src/ontology/iri_dependencies/chebi_terms.txt
@@ -2057,3 +2057,5 @@ http://purl.obolibrary.org/obo/CHEBI_68612
 http://purl.obolibrary.org/obo/CHEBI_35225
 http://purl.obolibrary.org/obo/CHEBI_30813
 http://purl.obolibrary.org/obo/CHEBI_28875
+http://purl.obolibrary.org/obo/CHEBI_46662
+http://purl.obolibrary.org/obo/CHEBI_27365

--- a/src/ontology/iri_dependencies/oba_terms.txt
+++ b/src/ontology/iri_dependencies/oba_terms.txt
@@ -24678,3 +24678,9 @@ http://purl.obolibrary.org/obo/OBA_0002566
 http://purl.obolibrary.org/obo/OBA_2081988
 http://purl.obolibrary.org/obo/OBA_1000407
 http://purl.obolibrary.org/obo/OBA_2045233
+http://purl.obolibrary.org/obo/OBA_2100001
+http://purl.obolibrary.org/obo/OBA_2100002
+http://purl.obolibrary.org/obo/OBA_2090004
+http://purl.obolibrary.org/obo/OBA_2100003
+http://purl.obolibrary.org/obo/OBA_2100004
+http://purl.obolibrary.org/obo/OBA_2100005

--- a/src/ontology/iri_dependencies/uberon_terms.txt
+++ b/src/ontology/iri_dependencies/uberon_terms.txt
@@ -1188,3 +1188,5 @@ http://purl.obolibrary.org/obo/UBERON_0006074
 http://purl.obolibrary.org/obo/UBERON_0012273
 http://purl.obolibrary.org/obo/UBERON_0000081
 http://purl.obolibrary.org/obo/UBERON_0006956
+http://purl.obolibrary.org/obo/UBERON_1200002
+http://purl.obolibrary.org/obo/UBERON_0006171


### PR DESCRIPTION
Added 10 new terms to iri_dependencies and regenerated imports:

OBA terms (6):
- OBA:2100001 vertebra mineral amount
- OBA:2100002 urine zinc amount
- OBA:2090004 carotid artery intima-media region thickness
- OBA:2100003 cortex of kidney volume
- OBA:2100004 renal medulla volume
- OBA:2100005 renal sinus volume

CHEBI terms (2):
- CHEBI:46662 mineral
- CHEBI:27365 zinc ion

UBERON terms (2):
- UBERON:1200002 carotid artery intima-media region
- UBERON:0006171 renal sinus

All terms validated via OLS and imports regenerated with updated mirrors.

Addresses #2467, #2590, #2466, #2537