### PR TITLE
Add MONDO_1060213 to imports and dependencies

### DIFF
--- a/src/ontology/imports/mondo_terms.txt
+++ b/src/ontology/imports/mondo_terms.txt
@@ -12289,6 +12289,7 @@ http://purl.obolibrary.org/obo/MONDO_1060152
 http://purl.obolibrary.org/obo/MONDO_1060177
 http://purl.obolibrary.org/obo/MONDO_1060179
 http://purl.obolibrary.org/obo/MONDO_1060185
+http://purl.obolibrary.org/obo/MONDO_1060213
 http://purl.obolibrary.org/obo/MONDO_8000000
 http://purl.obolibrary.org/obo/MONDO_8000006
 http://purl.obolibrary.org/obo/MONDO_8000010

--- a/src/ontology/iri_dependencies/mondo_terms.txt
+++ b/src/ontology/iri_dependencies/mondo_terms.txt
@@ -12292,3 +12292,4 @@ http://purl.obolibrary.org/obo/MONDO_8000011
 http://purl.obolibrary.org/obo/MONDO_8000012
 http://purl.obolibrary.org/obo/MONDO_0700325
 http://purl.obolibrary.org/obo/MONDO_0014337
+http://purl.obolibrary.org/obo/MONDO_1060213


### PR DESCRIPTION
Insert MONDO_1060213 into src/ontology/imports/mondo_terms.txt and src/ontology/iri_dependencies/mondo_terms.txt so the new MONDO term is included in the ontology imports and IRI dependency lists.

Addresses https://github.com/EBISPOT/efo/issues/2591