### PR TITLE
Fix allocate-definitive-ids by using ODK system robot wrapper

### DIFF
--- a/.github/workflows/allocate-definitive-ids.yml
+++ b/.github/workflows/allocate-definitive-ids.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Allocate definitive IDs
         run: |
           cd src/ontology
-          make allocate-definitive-ids ROBOT=robot
+          make allocate-definitive-ids "ROBOT=java -cp ../../bin/robot.jar:tmp/plugins/kgcl.jar org.obolibrary.robot.CommandManager"
 
       - name: Commit and push changes
         uses: actions-js/push@v1.5

--- a/.github/workflows/allocate-definitive-ids.yml
+++ b/.github/workflows/allocate-definitive-ids.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Allocate definitive IDs
         run: |
           cd src/ontology
-          make allocate-definitive-ids
+          make allocate-definitive-ids ROBOT=robot
 
       - name: Commit and push changes
         uses: actions-js/push@v1.5


### PR DESCRIPTION
The repo's bin/robot is a bare Java launcher with no plugin support. Using ROBOT=robot in the make call switches to the ODK container's system wrapper, which reads ROBOT_PLUGINS_DIRECTORY and loads the kgcl plugin required for kgcl:mint.