### PR TITLE
Import HP:0006292 'Abnormality of dental eruption' (#2723)

### DIFF
--- a/src/ontology/imports/hp_terms.txt
+++ b/src/ontology/imports/hp_terms.txt
@@ -1388,6 +1388,7 @@ http://purl.obolibrary.org/obo/HP_0006159
 http://purl.obolibrary.org/obo/HP_0006165
 http://purl.obolibrary.org/obo/HP_0006278
 http://purl.obolibrary.org/obo/HP_0006283
+http://purl.obolibrary.org/obo/HP_0006292
 http://purl.obolibrary.org/obo/HP_0006315
 http://purl.obolibrary.org/obo/HP_0006337
 http://purl.obolibrary.org/obo/HP_0006367

--- a/src/ontology/iri_dependencies/hp_terms.txt
+++ b/src/ontology/iri_dependencies/hp_terms.txt
@@ -2513,3 +2513,4 @@ http://purl.obolibrary.org/obo/HP_0008197
 http://purl.obolibrary.org/obo/HP_0003771
 http://purl.obolibrary.org/obo/HP_0030872
 http://purl.obolibrary.org/obo/HP_0012743
+http://purl.obolibrary.org/obo/HP_0006292


### PR DESCRIPTION
## Summary
Imports the HPO term **HP:0006292 "Abnormality of dental eruption"** into EFO, as requested in #2723 (GWAS Catalog import request). The term is imported under its existing HPO parent **HP:0000164 "Abnormality of the dentition"**, which was already present in the EFO HP import.

## Changes
| Action | Term | ID | Parent | Source ontology |
|--------|------|----|--------|-----------------|
| Imported | Abnormality of dental eruption | HP:0006292 | Abnormality of the dentition (HP:0000164) | HP |

Files changed:
- `src/ontology/iri_dependencies/hp_terms.txt` — added `http://purl.obolibrary.org/obo/HP_0006292`
- `src/ontology/imports/hp_import.owl` — regenerated
- `src/ontology/imports/hp_terms.txt` — regenerated

## References
- Source: HPO (`http://purl.obolibrary.org/obo/HP_0006292`) — verified bidirectionally via OLS (IRI ↔ label), not obsolete.
- Parent HP:0000164 verified via OLS (not obsolete) and already present in the HP import; HPO's asserted hierarchy places HP:0006292 directly under it.

## Checks
- [x] Term import requested (no new EFO term, no curation/PMID requirement)
- [x] Imported and parent terms verified non-obsolete via OLS
- [x] Import done via efo-importer; only `iri_dependencies/*.txt` hand-edited, generated `imports/` files regenerated
- [x] HP:0006292 connects directly under HP:0000164 in the regenerated import — not dangling, no `subclasses.csv` entry needed
- [x] `robot reason -i efo-edit.owl -r ELK` clean — no unsatisfiable classes

## Notes / open questions
None — the requested parent matches HPO's own asserted hierarchy, so the term integrates without any `efo-edit.owl` change.

Closes #2723