### PR TITLE
Fix allocate-definitive-ids workflow (use ODK system robot for kgcl)

### DIFF
--- a/.github/workflows/allocate-definitive-ids.yml
+++ b/.github/workflows/allocate-definitive-ids.yml
@@ -11,8 +11,11 @@ jobs:
   assign_ids:
     runs-on: ubuntu-latest
     container: obolibrary/odkfull:v1.6
+    # The ODK image ships ROBOT plugins (including kgcl) under
+    # /tools/robot-plugins. Point ROBOT there so `kgcl:mint` is available
+    # (this is the same location uberon's ODK Makefile installs plugins from).
     env:
-      ROBOT_PLUGINS_DIRECTORY: /odk/resources/robot/plugins
+      ROBOT_PLUGINS_DIRECTORY: /tools/robot-plugins
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -20,6 +23,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      # mondo_import.owl is gitignored (regenerated from the MONDO release),
+      # so it must be built before efo-edit.owl can resolve its imports.
+      # All other import modules are committed and resolved via catalog-v001.xml.
       - name: Prepare MONDO import
         run: |
           cd src/ontology
@@ -30,7 +36,12 @@ jobs:
       - name: Allocate definitive IDs
         run: |
           cd src/ontology
-          make allocate-definitive-ids "ROBOT=java -cp ../../bin/robot.jar:tmp/plugins/kgcl.jar org.obolibrary.robot.CommandManager"
+          echo "Available ROBOT plugins:" && ls -1 "$ROBOT_PLUGINS_DIRECTORY"
+          # Use the ODK system `robot` wrapper, which supports plugins and
+          # picks up kgcl from ROBOT_PLUGINS_DIRECTORY. The previous override
+          # (java -cp ... org.obolibrary.robot.CommandManager) was broken:
+          # CommandManager has no static main, so the JVM never started ROBOT.
+          make allocate-definitive-ids ROBOT="robot --catalog catalog-v001.xml"
 
       - name: Commit and push changes
         uses: actions-js/push@v1.5


### PR DESCRIPTION
## Summary
The **Allocate definitive EFO IDs** workflow has been failing on every run. Root cause: the `ROBOT=` override added in #2717 invoked

```
java -cp ../../bin/robot.jar:tmp/plugins/kgcl.jar org.obolibrary.robot.CommandManager kgcl:mint ...
```

which fails immediately — `org.obolibrary.robot.CommandManager` has no static `main()`, so the JVM never starts ROBOT:

```
Error: Main method is not static in class org.obolibrary.robot.CommandManager
```

It was also broken in two further ways: ROBOT loads plugins from `ROBOT_PLUGINS_DIRECTORY`, **not** from the classpath, and `tmp/plugins/kgcl.jar` was never created. The env var also pointed at a non-existent path (`/odk/resources/robot/plugins`).

## Fix
Mirror uberon's working ODK setup:
- Run `kgcl:mint` through the ODK image's **system `robot` wrapper** (plugin-capable) instead of a hand-rolled `java -cp` call.
- Set `ROBOT_PLUGINS_DIRECTORY: /tools/robot-plugins` — where the ODK image actually ships `kgcl.jar` (same location uberon's ODK Makefile uses).
- Pass `--catalog catalog-v001.xml` so `efo-edit.owl` imports resolve from the committed import modules.
- Keep the MONDO-import prep step (`mondo_import.owl` is gitignored / regenerated; the other 14 imports are committed).
- Log the available plugins for easier future diagnosis.

This PR contains **only the workflow change**. Once merged, the push to `master` triggers the workflow, which will then allocate definitive IDs for any pending temp IDs automatically.

## Verification
Triggered via `workflow_dispatch` on this branch — **run succeeded** ([28026147287](https://github.com/EBISPOT/efo/actions/runs/28026147287)). The log shows:
- `Available ROBOT plugins: kgcl.jar` (KGCL 0.5.1 found at `/tools/robot-plugins`)
- `robot --catalog catalog-v001.xml kgcl:mint ...` ran cleanly
- The pending temp ID (**systemic inflammation**, `EFO_0990000`) was minted and pushed during the test run; that test commit was removed so this PR stays workflow-only and the allocation runs on `master` after merge.