### PR TITLE
Stop allocate-definitive-ids self-trigger loop

### DIFF
--- a/.github/workflows/allocate-definitive-ids.yml
+++ b/.github/workflows/allocate-definitive-ids.yml
@@ -23,10 +23,29 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      # Only do anything if there are temporary IDs to allocate. This is
+      # essential: `robot convert` re-serialises efo-edit.owl's anonymous
+      # rdf:Description blocks in a non-deterministic order, so an
+      # unconditional run would rewrite (and commit) the file on every run,
+      # and that commit would re-trigger this workflow -> infinite loop.
+      # Guarding on temp IDs means a real allocation triggers at most one
+      # trailing no-op run, which then stops.
+      - name: Check for temporary IDs
+        id: check
+        run: |
+          if grep -q 'EFO_099' src/ontology/efo-edit.owl; then
+            echo "Temporary EFO_099 IDs found; will allocate."
+            echo "has_temp=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No temporary EFO_099 IDs; nothing to allocate."
+            echo "has_temp=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # mondo_import.owl is gitignored (regenerated from the MONDO release),
       # so it must be built before efo-edit.owl can resolve its imports.
       # All other import modules are committed and resolved via catalog-v001.xml.
       - name: Prepare MONDO import
+        if: steps.check.outputs.has_temp == 'true'
         run: |
           cd src/ontology
           mkdir -p mirror
@@ -34,6 +53,7 @@ jobs:
           make imports/mondo_import.owl
 
       - name: Allocate definitive IDs
+        if: steps.check.outputs.has_temp == 'true'
         run: |
           cd src/ontology
           echo "Available ROBOT plugins:" && ls -1 "$ROBOT_PLUGINS_DIRECTORY"
@@ -44,6 +64,7 @@ jobs:
           make allocate-definitive-ids ROBOT="robot --catalog catalog-v001.xml"
 
       - name: Commit and push changes
+        if: steps.check.outputs.has_temp == 'true'
         uses: actions-js/push@v1.5
         with:
           github_token: ${{ secrets.EFO_ID_ALLOCATION_TOKEN }}


### PR DESCRIPTION
## Problem
After #2725 fixed the workflow so it actually runs, it began **looping** — it ran ~11 times back-to-back on `master`, each pushing a `Replace temporary IDs by definitive IDs.` commit.

**Root cause:** the allocate step runs `robot ... kgcl:mint ... convert -f owl -o efo-edit.owl`. ROBOT re-serialises the ~13 anonymous `<rdf:Description>` blocks in `efo-edit.owl` (obsolete-term `IAO_0100001` replacement annotations) in a **non-deterministic order**. So every run rewrites the file even when there are **no temporary IDs to mint**. That commit touches `efo-edit.owl`, which matches the workflow's `paths:` filter, so it immediately re-triggers the workflow → infinite loop. (`normalize_src` is the same non-deterministic `robot convert`, so it can't stabilise it either.)

The temp ID allocation itself worked correctly — `systemic inflammation` got `EFO_0920000` — the bug is purely the self-perpetuating trigger.

## Fix
Guard the work on the presence of temporary `EFO_099` IDs:
- A `Check for temporary IDs` step greps `efo-edit.owl`.
- `Prepare MONDO import`, `Allocate definitive IDs`, and `Commit and push changes` run only `if` temp IDs are present.

A genuine allocation now triggers at most **one trailing no-op run** (temp IDs already minted → grep finds none → all steps skipped → no commit), which terminates the chain. No-op runs are also cheap now — they skip the MONDO download entirely.

## Notes
- The workflow is currently **disabled** (I disabled it to stop the live loop). **Re-enable it after merging this PR** (Actions → "Allocate definitive EFO IDs" → ⋯ → Enable, or `gh workflow enable "Allocate definitive EFO IDs"`).
- Current `master` has no temporary IDs, so the guarded workflow will be a no-op until a new `EFO_099xxxx` term is added.
- Residual cosmetic churn (~26 lines of rdf:Description reordering) will still appear inside *real* allocation commits; a deeper fix would be making the OWL serialization deterministic or giving those obsolete annotations explicit subjects — out of scope here.