### PR TITLE
efo-ticket: branch from an up-to-date master

### DIFF
--- a/.claude/commands/efo-ticket.md
+++ b/.claude/commands/efo-ticket.md
@@ -11,7 +11,12 @@ Work through these steps, tracking them with a todo list:
 1. **Read the ticket.** Run `gh issue view $1`. Read any linked issues. Extract every PMID/DOI in the title or body — they must be read during curation.
 2. **Triage** using the Routing table in `CLAUDE.md`. State your plan (which subagents, in what order) before acting.
 3. **OLS pre-check** (new terms): confirm the concept isn't already in an imported ontology. If it is, treat it as an import.
-4. **Create the branch:** `git checkout -b issue-$1`. If a branch/PR for this issue already exists, check it out and continue instead of starting over.
+4. **Create the branch from an up-to-date `master`.** Always start the issue branch from the latest `origin/master` so it never builds on stale or unrelated work:
+   ```bash
+   git fetch origin master
+   git checkout -b issue-$1 origin/master   # branches directly from fresh remote master
+   ```
+   Branching from `origin/master` guarantees freshness regardless of your current branch or local state. If you keep a local `master`, fast-forward it too: `git checkout master && git merge --ff-only origin/master`. Ensure the working tree is clean first (`git status`) — commit or stash unrelated changes before branching. If a branch/PR for this issue already exists, check it out and continue instead of starting over (rebase it onto the latest `origin/master` if it has fallen behind).
 5. **Dispatch the specialist subagents in sequence** via the Task tool, using the handoff template from `CLAUDE.md`:
    - `efo-curator` for research/validation (new terms, or definitions needing citations)
    - `efo-importer` for ANY external term (never import yourself)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ When given a ticket (via `/efo-ticket N` or "handle issue #N"):
 1. **Read the ticket.** `gh issue view N`. Read linked issues if referenced. Look for PMIDs/DOIs in title and body — if present, they must be read during curation.
 2. **Triage** using the Routing table below. Decide: simple edit, new term, import, or obsoletion.
 3. **Pre-creation OLS check (new terms only).** Search OLS yourself (or via the curator) to confirm the concept isn't already in an ontology we import from. If it is → it's an import, not a new EFO term.
-4. **Create the branch.** `git checkout -b issue-N` (if a PR/branch for this issue already exists, check it out and continue instead).
+4. **Create the branch from an up-to-date `master`.** Refresh first, then branch directly off the latest remote master: `git fetch origin master && git checkout -b issue-N origin/master`. This guarantees the branch is never based on stale or unrelated work. Ensure the working tree is clean before branching. (If a PR/branch for this issue already exists, check it out and continue instead — rebasing onto the latest `origin/master` if it has fallen behind.)
 5. **Dispatch subagents in sequence** per the routing decision. Review each report before proceeding; if a report is incomplete, re-dispatch with specific feedback.
 6. **Verify** (see Verification gate below).
 7. **Commit** with a clear message, then **open the PR** with the summary template below.


### PR DESCRIPTION
## Summary
The ticket workflow created the issue branch with `git checkout -b issue-N`, which branches from the current HEAD with no guarantee it's `master` or that `master` is current — so a ticket branch could be based on stale or unrelated work.

## Change
Step 4 now refreshes and branches directly off the latest remote master:

```bash
git fetch origin master
git checkout -b issue-N origin/master
```

Branching from `origin/master` guarantees freshness regardless of the current local branch/state. Also notes: keep a clean working tree before branching, fast-forward local `master` if kept, and rebase an existing issue branch onto the latest `origin/master` if it has fallen behind.

Applied to both:
- `.claude/commands/efo-ticket.md` (the `/efo-ticket` command)
- `CLAUDE.md` (the orchestrator guide used for "handle issue #N")

Docs-only; no code or ontology changes.