### PR TITLE
Import 12 UBERON GTEx tissue terms (#2727)

### DIFF
--- a/src/ontology/imports/uberon_terms.txt
+++ b/src/ontology/imports/uberon_terms.txt
@@ -736,6 +736,7 @@ http://purl.obolibrary.org/obo/UBERON_0004370
 http://purl.obolibrary.org/obo/UBERON_0004449
 http://purl.obolibrary.org/obo/UBERON_0004454
 http://purl.obolibrary.org/obo/UBERON_0004535
+http://purl.obolibrary.org/obo/UBERON_0004550
 http://purl.obolibrary.org/obo/UBERON_0004573
 http://purl.obolibrary.org/obo/UBERON_0004638
 http://purl.obolibrary.org/obo/UBERON_0004639
@@ -836,12 +837,15 @@ http://purl.obolibrary.org/obo/UBERON_0006238
 http://purl.obolibrary.org/obo/UBERON_0006240
 http://purl.obolibrary.org/obo/UBERON_0006241
 http://purl.obolibrary.org/obo/UBERON_0006314
+http://purl.obolibrary.org/obo/UBERON_0006330
 http://purl.obolibrary.org/obo/UBERON_0006334
+http://purl.obolibrary.org/obo/UBERON_0006469
 http://purl.obolibrary.org/obo/UBERON_0006479
 http://purl.obolibrary.org/obo/UBERON_0006483
 http://purl.obolibrary.org/obo/UBERON_0006530
 http://purl.obolibrary.org/obo/UBERON_0006558
 http://purl.obolibrary.org/obo/UBERON_0006562
+http://purl.obolibrary.org/obo/UBERON_0006566
 http://purl.obolibrary.org/obo/UBERON_0006595
 http://purl.obolibrary.org/obo/UBERON_0006596
 http://purl.obolibrary.org/obo/UBERON_0006597
@@ -850,6 +854,7 @@ http://purl.obolibrary.org/obo/UBERON_0006600
 http://purl.obolibrary.org/obo/UBERON_0006601
 http://purl.obolibrary.org/obo/UBERON_0006603
 http://purl.obolibrary.org/obo/UBERON_0006618
+http://purl.obolibrary.org/obo/UBERON_0006631
 http://purl.obolibrary.org/obo/UBERON_0006666
 http://purl.obolibrary.org/obo/UBERON_0006676
 http://purl.obolibrary.org/obo/UBERON_0006692
@@ -866,6 +871,7 @@ http://purl.obolibrary.org/obo/UBERON_0006877
 http://purl.obolibrary.org/obo/UBERON_0006904
 http://purl.obolibrary.org/obo/UBERON_0006908
 http://purl.obolibrary.org/obo/UBERON_0006914
+http://purl.obolibrary.org/obo/UBERON_0006920
 http://purl.obolibrary.org/obo/UBERON_0006956
 http://purl.obolibrary.org/obo/UBERON_0006965
 http://purl.obolibrary.org/obo/UBERON_0007097
@@ -915,6 +921,7 @@ http://purl.obolibrary.org/obo/UBERON_0007811
 http://purl.obolibrary.org/obo/UBERON_0007844
 http://purl.obolibrary.org/obo/UBERON_0008337
 http://purl.obolibrary.org/obo/UBERON_0008338
+http://purl.obolibrary.org/obo/UBERON_0008367
 http://purl.obolibrary.org/obo/UBERON_0008861
 http://purl.obolibrary.org/obo/UBERON_0008878
 http://purl.obolibrary.org/obo/UBERON_0008896
@@ -941,6 +948,7 @@ http://purl.obolibrary.org/obo/UBERON_0009582
 http://purl.obolibrary.org/obo/UBERON_0009616
 http://purl.obolibrary.org/obo/UBERON_0009676
 http://purl.obolibrary.org/obo/UBERON_0009773
+http://purl.obolibrary.org/obo/UBERON_0009835
 http://purl.obolibrary.org/obo/UBERON_0009853
 http://purl.obolibrary.org/obo/UBERON_0009854
 http://purl.obolibrary.org/obo/UBERON_0009881
@@ -956,6 +964,7 @@ http://purl.obolibrary.org/obo/UBERON_0010302
 http://purl.obolibrary.org/obo/UBERON_0010366
 http://purl.obolibrary.org/obo/UBERON_0010391
 http://purl.obolibrary.org/obo/UBERON_0010402
+http://purl.obolibrary.org/obo/UBERON_0010414
 http://purl.obolibrary.org/obo/UBERON_0010710
 http://purl.obolibrary.org/obo/UBERON_0010743
 http://purl.obolibrary.org/obo/UBERON_0010996
@@ -980,6 +989,7 @@ http://purl.obolibrary.org/obo/UBERON_0011818
 http://purl.obolibrary.org/obo/UBERON_0011826
 http://purl.obolibrary.org/obo/UBERON_0011892
 http://purl.obolibrary.org/obo/UBERON_0011905
+http://purl.obolibrary.org/obo/UBERON_0011907
 http://purl.obolibrary.org/obo/UBERON_0011932
 http://purl.obolibrary.org/obo/UBERON_0012168
 http://purl.obolibrary.org/obo/UBERON_0012170
@@ -997,6 +1007,7 @@ http://purl.obolibrary.org/obo/UBERON_0013203
 http://purl.obolibrary.org/obo/UBERON_0013229
 http://purl.obolibrary.org/obo/UBERON_0013691
 http://purl.obolibrary.org/obo/UBERON_0013702
+http://purl.obolibrary.org/obo/UBERON_0013756
 http://purl.obolibrary.org/obo/UBERON_0013768
 http://purl.obolibrary.org/obo/UBERON_0014371
 http://purl.obolibrary.org/obo/UBERON_0014374
@@ -1035,6 +1046,7 @@ http://purl.obolibrary.org/obo/UBERON_0035652
 http://purl.obolibrary.org/obo/UBERON_0035814
 http://purl.obolibrary.org/obo/UBERON_0035845
 http://purl.obolibrary.org/obo/UBERON_0035965
+http://purl.obolibrary.org/obo/UBERON_0036149
 http://purl.obolibrary.org/obo/UBERON_0036214
 http://purl.obolibrary.org/obo/UBERON_0036262
 http://purl.obolibrary.org/obo/UBERON_0036263

--- a/src/ontology/iri_dependencies/uberon_terms.txt
+++ b/src/ontology/iri_dependencies/uberon_terms.txt
@@ -1190,3 +1190,15 @@ http://purl.obolibrary.org/obo/UBERON_0000081
 http://purl.obolibrary.org/obo/UBERON_0006956
 http://purl.obolibrary.org/obo/UBERON_1200002
 http://purl.obolibrary.org/obo/UBERON_0006171
+http://purl.obolibrary.org/obo/UBERON_0006469
+http://purl.obolibrary.org/obo/UBERON_0009835
+http://purl.obolibrary.org/obo/UBERON_0006330
+http://purl.obolibrary.org/obo/UBERON_0008367
+http://purl.obolibrary.org/obo/UBERON_0006920
+http://purl.obolibrary.org/obo/UBERON_0011907
+http://purl.obolibrary.org/obo/UBERON_0004550
+http://purl.obolibrary.org/obo/UBERON_0006566
+http://purl.obolibrary.org/obo/UBERON_0010414
+http://purl.obolibrary.org/obo/UBERON_0006631
+http://purl.obolibrary.org/obo/UBERON_0036149
+http://purl.obolibrary.org/obo/UBERON_0013756


### PR DESCRIPTION
## Summary
Imports the 12 UBERON terms used in the [GTEx tissues list](https://www.gtexportal.org/home/samplingSitePage) that were missing in EFO. Requested by @ens-lgil for the OmicsPred project so these tissues can be linked directly to EFO. This is an import-only change — no new EFO terms were created and `efo-edit.owl` was not modified.

## Changes
All 12 IRIs appended to `src/ontology/iri_dependencies/uberon_terms.txt`; UBERON import regenerated (`make imports/uberon_import.owl -B`).

| Action | Term | UBERON ID | Parent (already imported) |
|--------|------|-----------|---------------------------|
| Imported | C1 segment of cervical spinal cord | UBERON_0006469 | part_of spinal cord (UBERON_0002240) |
| Imported | anterior cingulate cortex | UBERON_0009835 | part_of cingulate cortex (UBERON_0003027) |
| Imported | anterior lingual gland | UBERON_0006330 | is_a minor salivary gland (UBERON_0001830) |
| Imported | breast epithelium | UBERON_0008367 | epithelium part_of breast (UBERON_0000310) |
| Imported | esophagus squamous epithelium | UBERON_0006920 | squamous epithelium part_of esophagus (UBERON_0001043) |
| Imported | gastrocnemius medialis | UBERON_0011907 | part_of gastrocnemius (UBERON_0001388) |
| Imported | gastroesophageal sphincter | UBERON_0004550 | part_of cardia of stomach (UBERON_0001162) |
| Imported | left ventricle myocardium | UBERON_0006566 | myocardium of ventricle part_of heart left ventricle (UBERON_0001083 / UBERON_0002084) |
| Imported | omental fat pad | UBERON_0010414 | is_a adipose tissue; part_of omentum (UBERON_0003688) |
| Imported | right atrium auricular region | UBERON_0006631 | atrium auricular region part_of right cardiac atrium (UBERON_0006618 / UBERON_0002078) |
| Imported | suprapubic skin | UBERON_0036149 | zone of skin part_of hypogastric region (UBERON_0013203) |
| Imported | venous blood | UBERON_0013756 | is_a blood (UBERON_0000178) |

## Checks
- [x] All 12 IDs verified bidirectionally against OLS (exact label match, none obsolete)
- [x] IRIs added only to `iri_dependencies/uberon_terms.txt`; no hand-edited generated files
- [x] UBERON mirror refreshed and `make imports/uberon_import.owl -B` succeeded
- [x] All 12 terms carry `rdfs:label` and resolve to non-dangling, already-imported parents — no `subclasses.csv` axiom needed
- [x] `robot reason -i efo-edit.owl -r ELK` ran clean — no unsatisfiable classes

## Notes / open questions
For two terms, UBERON's own asserted parentage differs from the parent the requester suggested in the ticket (both still resolve to existing, non-dangling EFO classes, so no action was needed):
- **esophagus squamous epithelium (UBERON_0006920)** — UBERON models it as *squamous epithelium part_of esophagus*, not under "epithelium of esophagus" (UBERON_0001976).
- **suprapubic skin (UBERON_0036149)** — UBERON models it as *zone of skin part_of hypogastric region*, not under "skin of abdomen" (UBERON_0001416).

@ens-lgil — flagging these in case you want the EFO-side placement to match your suggested parents exactly; otherwise the upstream UBERON hierarchy is preserved as-is.

Closes #2727