### PR TITLE
Import head size trait (OBA_VT0000002) (#2705)

### DIFF
--- a/src/ontology/imports/oba_terms.txt
+++ b/src/ontology/imports/oba_terms.txt
@@ -17547,6 +17547,7 @@ http://purl.obolibrary.org/obo/OBA_2100002
 http://purl.obolibrary.org/obo/OBA_2100003
 http://purl.obolibrary.org/obo/OBA_2100004
 http://purl.obolibrary.org/obo/OBA_2100005
+http://purl.obolibrary.org/obo/OBA_VT0000002
 http://purl.obolibrary.org/obo/OBA_VT0000012
 http://purl.obolibrary.org/obo/OBA_VT0000047
 http://purl.obolibrary.org/obo/OBA_VT0000056

--- a/src/ontology/iri_dependencies/oba_terms.txt
+++ b/src/ontology/iri_dependencies/oba_terms.txt
@@ -24684,3 +24684,4 @@ http://purl.obolibrary.org/obo/OBA_2090004
 http://purl.obolibrary.org/obo/OBA_2100003
 http://purl.obolibrary.org/obo/OBA_2100004
 http://purl.obolibrary.org/obo/OBA_2100005
+http://purl.obolibrary.org/obo/OBA_VT0000002


### PR DESCRIPTION
## Summary
Imports the OBA term **head size trait** (`OBA:VT0000002`) into EFO, requested by GWAS Catalog (@Santhi1901). Import-only change — no new EFO terms and `efo-edit.owl` was not modified.

## Changes
| Action | Term | OBA ID | Hierarchy (from OBA, already imported) |
|--------|------|--------|----------------------------------------|
| Imported | head size trait | OBA_VT0000002 | is_a anatomical structure size (OBA_0000015) & anatomical entity attribute (OBA_0100003); part_of body size trait (OBA_VT0100005) |

Added one IRI to `src/ontology/iri_dependencies/oba_terms.txt` and regenerated `imports/oba_import.owl` (`make imports/oba_import.owl -B`).

## Checks
- [x] OBA ID verified bidirectionally against OLS (`OBA:VT0000002` = "head size trait", non-obsolete); ticket ID is correct (the "VT" accession style is normal for OBA)
- [x] IRI added only to `iri_dependencies/oba_terms.txt`; no hand-edited generated files
- [x] OBA mirror refreshed and `make imports/oba_import.owl -B` succeeded
- [x] Term carries `rdfs:label` and resolves to already-imported, non-obsolete parents — no `subclasses.csv` axiom needed
- [x] `robot reason -i efo-edit.owl -r ELK` ran clean — no unsatisfiable classes

## Notes / open questions
The ticket lists **body size trait (OBA_VT0100005)** as the "parent". In upstream OBA this is **not** the `is_a` parent — head size trait is connected to body size trait via a `part_of` (BFO_0000050) restriction, and both are siblings under `anatomical structure size` (OBA_0000015) / `anatomical entity attribute` (OBA_0100003). The import preserves OBA's own hierarchy as-is. If GWAS Catalog needs this anchored under a specific EFO measurement/trait class, that would be a separate curation step (a `subclasses.csv` cross-ontology axiom) — flagging for the reviewer.

@Santhi1901 — let me know if you need an additional EFO-side placement beyond the imported OBA hierarchy.

Closes #2705