### PR TITLE
docs: require hasDbXref provenance on synonyms

### DIFF
--- a/.claude/agents/efo-curator.md
+++ b/.claude/agents/efo-curator.md
@@ -14,7 +14,7 @@ You research, validate, and document EFO term metadata through systematic litera
 - **Definition** — precise, scientific, literature-supported
 - **≥2 PMID/DOI cross-references** (minimum for NEW terms; prefer PMID). Never guess an identifier — verify each.
 - **Parent term** candidate(s) with rationale (at least one `is_a`)
-- **Synonyms, typed**
+- **Synonyms, typed, with a source** — for every synonym record the PMID/DOI (or external-ontology ID) where you found it, so the ontologist can attach it as a `hasDbXref` provenance
 - **Ontology-placement recommendation** (EFO vs external)
 - **Confidence** assessment
 
@@ -33,11 +33,12 @@ You research, validate, and document EFO term metadata through systematic litera
    - General measurement/attribute → consider OBA
    - General cell type → CL; general anatomy → UBERON; chemical → ChEBI
    - Experimental factors / assays / EFO-specific concepts → EFO
-5. **Type the synonyms**:
+5. **Type the synonyms** and **record where each came from**:
    - Abbreviations/acronyms → `hasRelatedSynonym` (e.g. "5-ASA" for "5-aminosalicylic acid")
    - Brand/narrow → `hasNarrowSynonym` (e.g. "Asacol")
    - Exact → `hasExactSynonym`
    - Broader → `hasBroadSynonym`
+   - For **each** synonym, capture the **source** (PMID/DOI where it appears, or the external-ontology ID it was taken from). Synonyms get a `hasDbXref` provenance just like definitions do, so the ontologist needs the source from you. If a synonym has no traceable source, say so — do not invent one.
 6. **Domain checks**: measurements need an `is_about` target; diseases need a `has_disease_location`; cell types note markers/lineage/tissue. Flag if the literature doesn't supply these.
 
 ## Report format
@@ -48,7 +49,7 @@ You research, validate, and document EFO term metadata through systematic litera
 ## 2. Definition — proposed text + literature support (PMID — how it supports)
 ## 3. Cross-references — PMID (DOI) — title & relevance  [MINIMUM 2 for new terms]
 ## 4. Parent — proposed parent (EFO/ONT:ID) + justification + hierarchical context
-## 5. Synonyms — each with TYPE (exact/related/narrow/broad) and source
+## 5. Synonyms — each with TYPE (exact/related/narrow/broad) AND its source (PMID/DOI or external-ontology ID) for the `hasDbXref` provenance
 ## 6. Logical relationships — is_about / has_disease_location / part_of as applicable
 ## 7. Placement — ✅ EFO, or ⚠️ external ontology (which + why)
 ## 8. Notes — caveats

--- a/.claude/agents/efo-ontologist.md
+++ b/.claude/agents/efo-ontologist.md
@@ -10,7 +10,7 @@ model: sonnet
 You are the OWL/XML editing specialist for `src/ontology/efo-edit.owl`. You integrate pre-validated terms, edit, and obsolete — following EFO patterns exactly. **You do not research literature, you do not import external terms, you do not call other agents, and you do not run git** — you make the file edits, normalize, verify, and report what you changed back to the orchestrator.
 
 ## Preconditions (refuse if missing)
-For a **new term** you must have received: label; definition with **≥2 PMIDs**; verified non-obsolete parent(s); synonyms **with types**; any logical defs/relationships. For **external references**, the IRI must already be imported. If something's missing, stop and report:
+For a **new term** you must have received: label; definition with **≥2 PMIDs**; verified non-obsolete parent(s); synonyms **with types and their sources** (the PMID/DOI or external-ontology ID each synonym came from, for the `hasDbXref` provenance); any logical defs/relationships. For **external references**, the IRI must already be imported. If something's missing, stop and report:
 ```
 Cannot proceed: missing <items>. Need curator sign-off for <X> / import for <Y>.
 ```
@@ -37,11 +37,29 @@ Cannot proceed: missing <items>. Need curator sign-off for <X> / import for <Y>.
         <oboInOwl:hasExactSynonym><synonym></oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en"><label></rdfs:label>
     </owl:Class>
+    <!-- synonym provenance: one owl:Axiom per synonym that has a source -->
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://www.ebi.ac.uk/efo/EFO_099XXXX"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget><synonym></owl:annotatedTarget>
+        <oboInOwl:hasDbXref>PMID:12345678</oboInOwl:hasDbXref>
+    </owl:Axiom>
 ```
 PMIDs embed **inside** the definition element (see EFO:0700018). Minimum 2.
 
 ### Synonym types
 `hasExactSynonym` (same meaning) · `hasRelatedSynonym` (abbreviation/acronym) · `hasNarrowSynonym` (brand/more specific) · `hasBroadSynonym` (more general). Do **not** add RO terms to `efo-relations.txt` unless explicitly told.
+
+**Synonym provenance (just like definitions need xrefs).** Every synonym that the curator gave a source for must carry a `hasDbXref` recording where it came from (PMID/DOI, or the external-ontology ID it was lifted from). Encode it as a reified `owl:Axiom` on the synonym assertion, using the matching `annotatedProperty` for that synonym's type. Match the `annotatedTarget` text **exactly** to the synonym string. Example (pattern mirrors NCBITaxon synonyms already in the file, e.g. NCBITaxon:1076):
+```xml
+<owl:Axiom>
+    <owl:annotatedSource rdf:resource="http://www.ebi.ac.uk/efo/EFO_099XXXX"/>
+    <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+    <owl:annotatedTarget>5-ASA</owl:annotatedTarget>
+    <oboInOwl:hasDbXref>PMID:12345678</oboInOwl:hasDbXref>
+</owl:Axiom>
+```
+If the curator could not supply a source for a synonym, leave the bare synonym assertion (no axiom) and flag it for the PR rather than inventing an xref.
 
 ### Logical definition (genus-differentia)
 ```xml
@@ -71,7 +89,7 @@ make normalize_src
 robot convert -vvv -i efo-edit.owl -o /dev/null   # if syntax looks off
 robot reason -i efo-edit.owl -r ELK               # catch unsatisfiable classes
 ```
-Checklist: label + def + ≥2 xrefs + non-obsolete parent on every new term · logical def mirrors text · no deprecated parents · cross-ontology links in `subclasses.csv` only when needed · normalization clean.
+Checklist: label + def + ≥2 xrefs + non-obsolete parent on every new term · synonyms with a known source carry a `hasDbXref` provenance axiom · logical def mirrors text · no deprecated parents · cross-ontology links in `subclasses.csv` only when needed · normalization clean.
 
 ## Report format
 ```

--- a/.github/agents/EFO-curator.md
+++ b/.github/agents/EFO-curator.md
@@ -80,10 +80,11 @@ If parent term is suggested:
 2. Verify the parent is appropriate for the domain
 3. Check if the parent exists in EFO or needs to be imported
 
-If synonyms are provided:
+If synonyms are provided (or discovered during research):
 1. Verify each synonym appears in the literature
 2. Note which papers use which synonyms
 3. Distinguish exact synonyms from related terms
+4. **Record the source (PMID/DOI, or external-ontology ID) of every synonym.** Synonyms get a `hasDbXref` provenance just like definitions do, so EFO-ontologist needs the source from you for each one. If a synonym has no traceable source, say so — never invent one.
 
 ### Step 3: Cross-Reference Validation
 

--- a/.github/agents/EFO-ontologist.md
+++ b/.github/agents/EFO-ontologist.md
@@ -197,6 +197,25 @@ When adding synonyms, use the correct annotation property based on curator categ
 - **Exact synonyms** → `hasExactSynonym`
 - **Broader terms** → `hasBroadSynonym`
 
+**Synonym provenance (xref) — REQUIRED, just like definitions**:
+
+Every synonym for which @EFO-curator supplied a source must carry a `hasDbXref` recording where it came from (the PMID/DOI, or the external-ontology ID it was lifted from). Encode it as a reified `owl:Axiom` on the synonym assertion, using the `annotatedProperty` that matches the synonym's type. The `annotatedTarget` text must match the synonym string exactly. This mirrors the NCBITaxon synonyms already present in `efo-edit.owl` (e.g. NCBITaxon:1076).
+
+```xml
+<!-- the bare synonym assertion on the class -->
+<oboInOwl:hasRelatedSynonym>5-ASA</oboInOwl:hasRelatedSynonym>
+
+<!-- its provenance, as a sibling owl:Axiom -->
+<owl:Axiom>
+    <owl:annotatedSource rdf:resource="http://www.ebi.ac.uk/efo/EFO_XXXXXXX"/>
+    <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+    <owl:annotatedTarget>5-ASA</owl:annotatedTarget>
+    <oboInOwl:hasDbXref>PMID:12345678</oboInOwl:hasDbXref>
+</owl:Axiom>
+```
+
+If the curator could not supply a source for a synonym, keep the bare synonym assertion (no axiom) and flag it for the PR — never invent an xref.
+
 #### 2. Definition with Embedded PMIDs
 
 **MINIMUM 2 PMID REFERENCES REQUIRED for all new terms**
@@ -392,6 +411,8 @@ Types of synonyms in EFO:
 - `oboInOwl:hasNarrowSynonym`: Synonym is more specific
 - `oboInOwl:hasBroadSynonym`: Synonym is more general
 - `oboInOwl:hasRelatedSynonym`: Related but not equivalent
+
+Each synonym with a known source must also carry a `hasDbXref` provenance via a reified `owl:Axiom` (see "Synonym provenance (xref)" above).
 
 ### Version Management
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -367,14 +367,15 @@ This section describes how to coordinate work across the three specialized EFO a
   - **Exact synonyms** → Mark as `hasExactSynonym`
   - **Broader terms** → Mark as `hasBroadSynonym`
 - EFO-curator should provide this categorization in the curation report
-- Example format:
+- EFO-curator should ALSO record the **source** of each synonym (the PMID/DOI where it appears, or the external-ontology ID it was taken from). Synonyms carry a `hasDbXref` provenance just like definitions do, so the source must be passed to EFO-ontologist. If a synonym has no traceable source, say so — never invent one.
+- Example format (note the source on every synonym):
   ```
   Synonyms:
-  - 5-aminosalicylic acid (hasExactSynonym)
-  - 5-ASA (hasRelatedSynonym - abbreviation)
-  - mesalazine (hasExactSynonym)
-  - Asacol (hasNarrowSynonym - brand name)
-  - Pentasa (hasNarrowSynonym - brand name)
+  - 5-aminosalicylic acid (hasExactSynonym) — PMID:12345678
+  - 5-ASA (hasRelatedSynonym - abbreviation) — PMID:12345678
+  - mesalazine (hasExactSynonym) — PMID:23456789
+  - Asacol (hasNarrowSynonym - brand name) — PMID:23456789
+  - Pentasa (hasNarrowSynonym - brand name) — PMID:23456789
   ```
 
 #### EFO-importer  
@@ -502,7 +503,7 @@ Dependencies: None, proceed with analysis
 Before requesting @EFO-ontologist to edit `src/ontology/efo-edit.owl` for **any new term**, the following must be present:
 
 **Required from @EFO-curator:**
-- Curator output attached: definitions, **minimum 2 PMIDs/DOIs**, synonyms **with type categorization** (exact/related/narrow/broad), suggested parent(s), and confidence assessment
+- Curator output attached: definitions, **minimum 2 PMIDs/DOIs**, synonyms **with type categorization** (exact/related/narrow/broad) **and a source (PMID/DOI or external-ontology ID) for each**, suggested parent(s), and confidence assessment
 - OR explicit curator sign-off: `@EFO-curator: SIGN-OFF`
 
 **Required from @EFO-importer (if applicable):**
@@ -512,7 +513,7 @@ Before requesting @EFO-ontologist to edit `src/ontology/efo-edit.owl` for **any 
 - Label
 - Textual definition with **minimum 2 PMIDs embedded as xrefs**
 - Parent term(s) - **VERIFIED as non-obsolete**
-- Synonyms (if any) - **WITH type categorization** (exact/related/narrow/broad)
+- Synonyms (if any) - **WITH type categorization** (exact/related/narrow/broad) **and a source for each** (PMID/DOI or external-ontology ID), to be added as a `hasDbXref` provenance axiom
 - Logical definitions and relationships (if applicable)
 
 **EFO-ontologist MUST verify these preconditions.** If any are missing, refuse to proceed and respond with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ These are the rules you and the subagents must never violate. Deep technical det
 - **≥2 PMID references**, embedded as nested `<oboInOwl:hasDbXref>` inside the `obo:IAO_0000115` definition (see `efo-ontologist` spec for the exact XML). Prefer PMID over DOI. Never guess a PMID — web-search if needed.
 - Every term needs: id, label, definition (with xrefs), and at least one `is_a` parent (explicit or via logical definition).
 - New terms use **temporary IDs `EFO_099xxxx`**. Check for clashes: `grep EFO_099 src/ontology/efo-edit.owl`. Definitive IDs are allocated later by automation.
-- Synonyms must be **typed**: abbreviations/acronyms → `hasRelatedSynonym`; brand/narrow → `hasNarrowSynonym`; exact → `hasExactSynonym`; broader → `hasBroadSynonym`.
+- Synonyms must be **typed**: abbreviations/acronyms → `hasRelatedSynonym`; brand/narrow → `hasNarrowSynonym`; exact → `hasExactSynonym`; broader → `hasBroadSynonym`. Each synonym must also carry a **`hasDbXref` source** (the PMID/DOI or external-ontology ID it came from), encoded as a reified `owl:Axiom` on the synonym assertion — just like definitions are xref'd. The curator supplies the source per synonym; if none is traceable, the synonym stays bare and the gap is flagged in the PR.
 - Domain expectations: **disease terms** → `has_disease_location` (may be inherited; if not provided, leave a PR comment). **Measurement terms** → `is_about` the measured entity/process (same rule). Logical definitions follow genus-differentia and mirror the text definition.
 
 ### Imports (always delegated to `efo-importer`)


### PR DESCRIPTION
## Summary
When agents create new terms, synonyms found in the literature were being added without a source xref, even though definitions are always xref'd. This PR updates the agent instructions so that **every synonym carries a `hasDbXref` provenance** — the PMID/DOI (or external-ontology ID) it came from — recorded as a reified `owl:Axiom` on the synonym assertion, mirroring how NCBITaxon synonyms are already encoded in `efo-edit.owl`.

The curator now explicitly records each synonym's source; the ontologist encodes it as an axiom; synonyms with no traceable source stay bare and are flagged for the PR rather than getting an invented xref.

## Changes
| File | Change |
|------|--------|
| `.claude/agents/efo-curator.md` | Record a source per synonym for the `hasDbXref` provenance; report-format updated |
| `.claude/agents/efo-ontologist.md` | Synonym-provenance `owl:Axiom` XML pattern + precondition + verify checklist |
| `.github/agents/EFO-curator.md` | Record source for every synonym (incl. discovered ones) |
| `.github/agents/EFO-ontologist.md` | Synonym-provenance XML pattern + note in "Handling Synonyms" |
| `.github/copilot-instructions.md` | Source required per synonym in curator output and ontologist inputs |
| `CLAUDE.md` | Orchestrator policy: synonyms need a `hasDbXref` source |

## Notes
- The synonym-xref pattern matches existing reified-axiom synonyms in the ontology (e.g. NCBITaxon:1076, NCBITaxon:10029).
- The `/review-pr` reviewer (`ontology-pr-reviewer`) was **also** updated to check that new synonyms carry a source xref (🟡 IMPORTANT if missing) — but that agent and the `review-pr` skill live at user level (`~/.claude/`), outside this repo, so those changes are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)