### PR TITLE
Obsolete environmental exposure measurement terms (issue #2737)

### DIFF
--- a/src/ontology/imports/ecto_import.owl
+++ b/src/ontology/imports/ecto_import.owl
@@ -209,6 +209,7 @@ A continuant cannot be part of an occurrent: use &apos;participates in&apos;. An
     <!-- http://purl.obolibrary.org/obo/ECTO_0000001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_0000001">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ECTO_8000000"/>
         <obo:IAO_0000115>A exposure event involving the interaction of an exposure receptor to radiation.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>radiation exposure</oboInOwl:hasExactSynonym>
         <rdfs:label>exposure to radiation</rdfs:label>
@@ -287,9 +288,30 @@ A continuant cannot be part of an occurrent: use &apos;participates in&apos;. An
     
 
 
+    <!-- http://purl.obolibrary.org/obo/ECTO_7000068 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_7000068">
+        <obo:IAO_0000115>A exposure event involving the interaction of an exposure receptor to particulate environmental material.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym>particulate environmental material exposure</oboInOwl:hasExactSynonym>
+        <rdfs:label>exposure to particulate matter</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ECTO_8000000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_8000000">
+        <obo:IAO_0000115>A exposure event involving the interaction of an exposure receptor to environmental system process.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym>environmental system process exposure</oboInOwl:hasExactSynonym>
+        <rdfs:label>exposure to environmental process</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/ECTO_8000036 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ECTO_8000036">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ECTO_8000000"/>
         <obo:IAO_0000115>A exposure event involving the interaction of an exposure receptor to air pollution.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>air pollution exposure</oboInOwl:hasExactSynonym>
         <rdfs:label>exposure to air pollution</rdfs:label>

--- a/src/ontology/imports/ecto_terms.txt
+++ b/src/ontology/imports/ecto_terms.txt
@@ -9,6 +9,8 @@ http://purl.obolibrary.org/obo/ECTO_0000726
 http://purl.obolibrary.org/obo/ECTO_0070164
 http://purl.obolibrary.org/obo/ECTO_1000034
 http://purl.obolibrary.org/obo/ECTO_6000029
+http://purl.obolibrary.org/obo/ECTO_7000068
+http://purl.obolibrary.org/obo/ECTO_8000000
 http://purl.obolibrary.org/obo/ECTO_8000036
 http://purl.obolibrary.org/obo/ECTO_9000026
 http://purl.obolibrary.org/obo/ECTO_9000033

--- a/src/ontology/iri_dependencies/ecto_terms.txt
+++ b/src/ontology/iri_dependencies/ecto_terms.txt
@@ -13,6 +13,8 @@ http://purl.obolibrary.org/obo/ECTO_0000001
 http://purl.obolibrary.org/obo/ECTO_0000006
 http://purl.obolibrary.org/obo/ECTO_9000097
 http://purl.obolibrary.org/obo/ECTO_9000078
+http://purl.obolibrary.org/obo/ECTO_8000000
+http://purl.obolibrary.org/obo/ECTO_7000068
 
 
 


### PR DESCRIPTION
## Summary
Completes the EFO→ECTO migration begun in #2380. The EFO-native **"environmental exposure measurement"** branch (`EFO_0008360`, 25 terms) is deprecated in favour of **ECTO** (Environmental Conditions, Treatments and Exposures Ontology) exposure classes. 18 terms had a verified ECTO equivalent and are obsoleted with `obo:IAO_0100001` (*term replaced by*) → the ECTO class; 7 terms have no ECTO equivalent and are kept (re-parented under `measurement`). Closes #2737.

## Obsoleted + replaced (18)
Each term gets: `obsolete_` label · `owl:deprecated=true` · `efo:obsoleted_in_version 3.92` · `efo:reason_for_obsolescence` (refs #2737) · `obo:IAO_0100001` → ECTO class · **all** logical axioms removed.

| EFO ID | EFO label | → ECTO ID | ECTO label |
|--------|-----------|-----------|------------|
| EFO_0008360 | environmental exposure measurement *(branch root)* | ECTO_8000000 | exposure to environmental process |
| EFO_0004806 | asbestos exposure measurement | ECTO_9000033 | exposure to asbestos |
| EFO_0006924 | household air pollution measurement | ECTO_8000036 | exposure to air pollution |
| EFO_0007840 | pesticide exposure measurement | ECTO_0000530 | exposure to pesticide |
| EFO_0007908 | traffic air pollution measurement | ECTO_8000036 | exposure to air pollution |
| EFO_0007944 | allergen exposure measurement | ECTO_0000726 | exposure to allergen |
| EFO_0008255 | particulate matter air pollution measurement | ECTO_7000068 | exposure to particulate matter |
| EFO_0008361 | environmental tobacco smoke exposure measurement | ECTO_6000029 | exposure to tobacco smoking |
| EFO_0008362 | farm exposure measurement | ECTO_1000034 | exposure to farm |
| EFO_0009113 | alcohol exposure measurement | ECTO_9000026 | exposure to alcohol |
| EFO_0009115 | tobacco smoke exposure measurement | ECTO_6000029 | exposure to tobacco smoking |
| EFO_0009370 | radon exposure measurement | ECTO_9000097 | exposure to radon |
| EFO_0010233 | genotoxic compound exposure measurement | ECTO_0000724 | exposure to genotoxin |
| EFO_0020980 | radiation exposure measurement | ECTO_0000001 | exposure to radiation |
| EFO_0022039 | ultraviolet radiation exposure measurement | ECTO_0000006 | exposure to ultraviolet radiation |
| EFO_0600007 | fish oil supplement exposure measurement | ECTO_0070164 | exposure to fish oil supplement via ingestion |
| EFO_0801078 | triclosan measurement | ECTO_9000078 | exposure to triclosan |
| EFO_0801079 | bisphenol A measurement | ECTO_9000057 | exposure to bisphenol A |

**Mappings to double-check** (best available in ECTO, flagged for reviewer):
- `EFO_0008361` environmental tobacco smoke (passive / second-hand) → `ECTO_6000029` **exposure to tobacco smoking** (active-smoking sense) — only ECTO option, semantically broader.
- `EFO_0006924` household + `EFO_0007908` traffic air pollution → both collapse to the generic `ECTO_8000036` **exposure to air pollution** (no household- or traffic-specific ECTO class exists).
- `EFO_0008360` root → `ECTO_8000000` **exposure to environmental process** (ECTO's top-level environmental-exposure grouping).

## Kept — no ECTO equivalent (7)
Not obsoleted. The 4 former direct children of the (obsoleted) root are re-parented to **measurement (`EFO_0001444`)**; the other 3 stay under their kept intermediate parents.

| EFO ID | EFO label | disposition |
|--------|-----------|-------------|
| EFO_0009114 | in utero exposure measurement | re-parented → measurement |
| EFO_0600015 | noise exposure measurement | re-parented → measurement |
| EFO_0600066 | nutritional supplement exposure measurement | re-parented → measurement |
| EFO_0600081 | time spent outdoors measurement | re-parented → measurement |
| EFO_0009116 | vitamin supplement exposure measurement | unchanged (under EFO_0600066) |
| EFO_0600067 | mastiha supplement exposure measurement | unchanged (under EFO_0600066) |
| EFO_0010729 | sun exposure measurement | unchanged (under EFO_0600081) |

## Terms that need creating in ECTO
These 7 have no ECTO class today. To eventually migrate them too, ECTO would need new *exposure to …* classes (new-term requests). Suggested labels + fit notes:

| EFO term | suggested new ECTO class | note |
|----------|--------------------------|------|
| noise exposure measurement (EFO_0600015) | exposure to noise | straightforward; cf. non-ECTO `LFID:0000230` "exposure to noise pollution" |
| sun exposure measurement (EFO_0010729) | exposure to sunlight | cf. non-ECTO `LFID:0000226`; broader than the existing ECTO "exposure to ultraviolet radiation" |
| nutritional supplement exposure measurement (EFO_0600066) | exposure to dietary supplement | genus for the two below (ECTO already has "exposure to fish oil supplement via ingestion") |
| vitamin supplement exposure measurement (EFO_0009116) | exposure to vitamin supplement | child of the above |
| mastiha supplement exposure measurement (EFO_0600067) | exposure to mastiha | obscure; low priority |
| in utero exposure measurement (EFO_0009114) | *(route-based, may not need a class)* | ECTO models this compositionally as "exposure to X **via maternal**" (ExO route `maternal`), not as a standalone class |
| time spent outdoors measurement (EFO_0600081) | *(poor fit)* | a behavioural duration, not "exposure to a stressor" — likely outside ECTO's exposure-event model |

## Imports
Added `ECTO_8000000` and `ECTO_7000068` to `src/ontology/iri_dependencies/ecto_terms.txt` and regenerated `src/ontology/imports/ecto_import.owl` (via efo-importer). No hand-editing of generated import files — ECTO's own class / definition / hierarchy axioms come straight from the ECTO release.

## Verification
- All 18 ECTO replacement targets verified non-obsolete via OLS (bidirectional label match).
- Branch is self-contained: no EFO term outside these 25 references any of them (only external GWAS annotation data does), so obsoletion creates no dangling references.
- `make normalize_src` clean; `robot reason` (ELK) → **no unsatisfiable classes**. *(Run locally with a temporary empty stub for the gitignored, not-yet-generated `imports/mondo_import.owl`; CI runs the full import pipeline.)*

## Open question
The 7 "no ECTO equivalent" terms are **kept** (re-parented) rather than obsoleted-without-replacement, to avoid orphaning their existing GWAS annotations. If the branch should instead be **fully retired**, they can be obsoleted too (with no replacement).

Closes #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jki5T73Qgyb2VGMuWsWtZy