### PR TITLE
docs: flag temporary agent-generated EFO IDs in PRs

### DIFF
--- a/.claude/agents/efo-ontologist.md
+++ b/.claude/agents/efo-ontologist.md
@@ -17,7 +17,7 @@ Cannot proceed: missing <items>. Need curator sign-off for <X> / import for <Y>.
 
 ## Workflow 1 — Add a new term
 1. Confirm all required components are present.
-2. Generate a temporary ID in range **`EFO_099xxxx`**; check clashes: `grep EFO_099 src/ontology/efo-edit.owl` (if creating several, ensure none collide).
+2. Generate a temporary ID in range **`EFO_099xxxx`** for each term **you** author; check clashes: `grep EFO_099 src/ontology/efo-edit.owl` (if creating several, ensure none collide). This range is the marker that automation uses to mint a definitive ID after merge, so it must be obvious in the PR that these IDs are temporary. **Exception:** if the handoff gives you a term that already has a real, non-`EFO_099xxxx` ID (a human-authored term), keep that ID exactly — it is permanent. Never renumber a permanent ID into the `EFO_099xxxx` range, and never invent an `EFO_099xxxx` ID for a term that already has a definitive one.
 3. Format the term following the template below and place it appropriately in `efo-edit.owl`.
 4. Add `SubClassOf` parent(s); add logical definition (genus-differentia) if there's a clear pattern; add domain relationships (`is_about`, `has_disease_location`, `part_of`).
 5. For cross-ontology `SubClassOf`, add a row to `src/templates/subclasses.csv` (`EFO_ID,EXTERNAL_ID`) **only if** it doesn't exist upstream, then `make components/subclasses.owl`.
@@ -94,7 +94,7 @@ Checklist: label + def + ≥2 xrefs + non-obsolete parent on every new term · s
 ## Report format
 ```
 INTEGRATION COMPLETE
-- Added/Edited/Obsoleted: <label> (EFO_099XXXX)
+- Added/Edited/Obsoleted: <label> (EFO_099XXXX — temporary, agent-generated ID)
 - Parent: <label> (ONT:YYYYYYY)
 - Definition: <text> [PMID:..., PMID:...]
 - Files changed: efo-edit.owl[, subclasses.csv]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,8 @@ These are the rules you and the subagents must never violate. Deep technical det
 ### New terms
 - **≥2 PMID references**, embedded as nested `<oboInOwl:hasDbXref>` inside the `obo:IAO_0000115` definition (see `efo-ontologist` spec for the exact XML). Prefer PMID over DOI. Never guess a PMID — web-search if needed.
 - Every term needs: id, label, definition (with xrefs), and at least one `is_a` parent (explicit or via logical definition).
-- New terms use **temporary IDs `EFO_099xxxx`**. Check for clashes: `grep EFO_099 src/ontology/efo-edit.owl`. Definitive IDs are allocated later by automation.
+- New terms **authored by an agent** use **temporary IDs `EFO_099xxxx`**. Check for clashes: `grep EFO_099 src/ontology/efo-edit.owl`. Definitive IDs are minted automatically after merge to `master` (`.github/workflows/allocate-definitive-ids.yml`, which replaces every `EFO_099xxxx` ID). The `EFO_099xxxx` range **is** the marker of a temporary, agent-generated ID.
+- **A manually-authored term keeps its ID permanently — even when an agent opens the PR.** If the user (or you, at their instruction) created a term with a real, non-`EFO_099xxxx` ID, that ID is definitive: never relabel it "temporary" and never renumber it into the `EFO_099xxxx` range. Temporary-vs-permanent is decided purely by whether the ID is in the `EFO_099xxxx` range, not by who opened the PR.
 - Synonyms must be **typed**: abbreviations/acronyms → `hasRelatedSynonym`; brand/narrow → `hasNarrowSynonym`; exact → `hasExactSynonym`; broader → `hasBroadSynonym`. Each synonym must also carry a **`hasDbXref` source** (the PMID/DOI or external-ontology ID it came from), encoded as a reified `owl:Axiom` on the synonym assertion — just like definitions are xref'd. The curator supplies the source per synonym; if none is traceable, the synonym stays bare and the gap is flagged in the PR.
 - Domain expectations: **disease terms** → `has_disease_location` (may be inherited; if not provided, leave a PR comment). **Measurement terms** → `is_about` the measured entity/process (same rule). Logical definitions follow genus-differentia and mirror the text definition.
 
@@ -142,10 +143,12 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 ## Summary
 <what was done and why>
 
+> ⚠️ **Temporary IDs:** every `EFO_099xxxx` ID below is a placeholder for an **agent-generated** term. It is replaced with a definitive EFO ID by automation after this PR merges to `master` — do not treat these numbers as stable. (Any non-`EFO_099xxxx` ID in the table is a permanent, manually-assigned ID and stays as-is.)
+
 ## Changes
-| Action | Term | EFO ID | Parent | Source ontology |
-|--------|------|--------|--------|-----------------|
-| Added | neutrophilic bronchiectasis | EFO_0990124 | bronchiectasis (MONDO:0004822) | — |
+| Action | Term | EFO ID | Temp? | Parent | Source ontology |
+|--------|------|--------|-------|--------|-----------------|
+| Added | neutrophilic bronchiectasis | EFO_0990124 | ⚠️ temporary | bronchiectasis (MONDO:0004822) | — |
 
 ## References
 - PMID:30215383 — <relevance>
@@ -155,6 +158,7 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 - [x] Parents verified non-obsolete
 - [x] ≥2 PMIDs per new term, synonyms typed
 - [x] `make normalize_src` clean; `robot reason` OK
+- [x] Temporary `EFO_099xxxx` IDs flagged as such (omit the callout/column only if the PR adds no agent-generated terms)
 
 ## Notes / open questions
 <anything the reviewer should weigh in on — e.g. missing has_disease_location>


### PR DESCRIPTION
## Summary
Agent-authored new terms are given **temporary `EFO_099xxxx` IDs** that the `allocate-definitive-ids.yml` workflow replaces with definitive IDs after merge to `master`. This PR makes that temporariness **obvious in the PR itself**, so a reviewer never mistakes a placeholder for a stable ID — while ensuring **manually-authored terms keep their permanent IDs even when an agent opens the PR**.

The distinction is drawn purely by the ID range: `EFO_099xxxx` = temporary/agent-generated; anything else = permanent. It does **not** depend on who opened the PR.

## Changes
| File | Change |
|------|--------|
| `CLAUDE.md` (New terms policy) | Clarify that only agent-authored terms use `EFO_099xxxx`; a manual term's ID is permanent even when an agent opens the PR; never renumber a permanent ID into the temp range. |
| `CLAUDE.md` (PR template) | Add a ⚠️ temporary-IDs callout, a `Temp?` column in the Changes table, and a Checks item requiring temp IDs to be flagged. |
| `.claude/agents/efo-ontologist.md` | Same temp-vs-permanent rule at ID-generation time; note that a handed-off permanent ID must be preserved; report format marks the ID as temporary. |

## Notes
- No ontology content changes — instructions/docs only.
- Rationale grounded in `.github/workflows/allocate-definitive-ids.yml`, which triggers on `EFO_099` and mints definitive IDs post-merge.

_Docs-only change; no issue to close._