### PR TITLE
fix: two MONDO-import CI failures (nolabels + check_mondo_obsoletes)

### DIFF
--- a/src/ontology/imports/mondo_terms.txt
+++ b/src/ontology/imports/mondo_terms.txt
@@ -5423,6 +5423,7 @@ http://purl.obolibrary.org/obo/MONDO_0012335
 http://purl.obolibrary.org/obo/MONDO_0012341
 http://purl.obolibrary.org/obo/MONDO_0012342
 http://purl.obolibrary.org/obo/MONDO_0012345
+http://purl.obolibrary.org/obo/MONDO_0012350
 http://purl.obolibrary.org/obo/MONDO_0012351
 http://purl.obolibrary.org/obo/MONDO_0012353
 http://purl.obolibrary.org/obo/MONDO_0012354

--- a/src/ontology/iri_dependencies/mondo_exclude.txt
+++ b/src/ontology/iri_dependencies/mondo_exclude.txt
@@ -3761,8 +3761,11 @@ http://purl.obolibrary.org/obo/GO_0003845
 http://purl.obolibrary.org/obo/GO_0005747
 http://purl.obolibrary.org/obo/GO_0005750
 http://purl.obolibrary.org/obo/GO_0005753
+http://purl.obolibrary.org/obo/GO_0006559
+http://purl.obolibrary.org/obo/GO_0006569
 http://purl.obolibrary.org/obo/GO_0007568
 http://purl.obolibrary.org/obo/GO_0010259
+http://purl.obolibrary.org/obo/GO_0016592
 http://purl.obolibrary.org/obo/GO_0055056
 http://purl.obolibrary.org/obo/HP_0002023
 http://purl.obolibrary.org/obo/HP_0012826
@@ -3916,6 +3919,7 @@ http://purl.obolibrary.org/obo/NCBITaxon_1647
 http://purl.obolibrary.org/obo/NCBITaxon_1648
 http://purl.obolibrary.org/obo/NCBITaxon_1654
 http://purl.obolibrary.org/obo/NCBITaxon_1659
+http://purl.obolibrary.org/obo/NCBITaxon_1678143
 http://purl.obolibrary.org/obo/NCBITaxon_168
 http://purl.obolibrary.org/obo/NCBITaxon_169418
 http://purl.obolibrary.org/obo/NCBITaxon_169495
@@ -3954,7 +3958,9 @@ http://purl.obolibrary.org/obo/NCBITaxon_260964
 http://purl.obolibrary.org/obo/NCBITaxon_2697049
 http://purl.obolibrary.org/obo/NCBITaxon_2702
 http://purl.obolibrary.org/obo/NCBITaxon_272561
+http://purl.obolibrary.org/obo/NCBITaxon_2732541
 http://purl.obolibrary.org/obo/NCBITaxon_27458
+http://purl.obolibrary.org/obo/NCBITaxon_27829
 http://purl.obolibrary.org/obo/NCBITaxon_27973
 http://purl.obolibrary.org/obo/NCBITaxon_28314
 http://purl.obolibrary.org/obo/NCBITaxon_28844
@@ -3969,6 +3975,9 @@ http://purl.obolibrary.org/obo/NCBITaxon_299467
 http://purl.obolibrary.org/obo/NCBITaxon_2995234
 http://purl.obolibrary.org/obo/NCBITaxon_3044472
 http://purl.obolibrary.org/obo/NCBITaxon_3044781
+http://purl.obolibrary.org/obo/NCBITaxon_3044783
+http://purl.obolibrary.org/obo/NCBITaxon_3052230
+http://purl.obolibrary.org/obo/NCBITaxon_3052310
 http://purl.obolibrary.org/obo/NCBITaxon_31704
 http://purl.obolibrary.org/obo/NCBITaxon_318479
 http://purl.obolibrary.org/obo/NCBITaxon_32008

--- a/src/ontology/iri_dependencies/mondo_terms.txt
+++ b/src/ontology/iri_dependencies/mondo_terms.txt
@@ -24,6 +24,7 @@ http://purl.obolibrary.org/obo/MONDO_0000200
 http://purl.obolibrary.org/obo/MONDO_0000208
 http://purl.obolibrary.org/obo/MONDO_0000212
 http://purl.obolibrary.org/obo/MONDO_0000226
+http://purl.obolibrary.org/obo/MONDO_0000245
 http://purl.obolibrary.org/obo/MONDO_0000266
 http://purl.obolibrary.org/obo/MONDO_0000270
 http://purl.obolibrary.org/obo/MONDO_0000309
@@ -178,6 +179,7 @@ http://purl.obolibrary.org/obo/MONDO_0001371
 http://purl.obolibrary.org/obo/MONDO_0001374
 http://purl.obolibrary.org/obo/MONDO_0001382
 http://purl.obolibrary.org/obo/MONDO_0001397
+http://purl.obolibrary.org/obo/MONDO_0001405
 http://purl.obolibrary.org/obo/MONDO_0001406
 http://purl.obolibrary.org/obo/MONDO_0001410
 http://purl.obolibrary.org/obo/MONDO_0001416
@@ -186,6 +188,7 @@ http://purl.obolibrary.org/obo/MONDO_0001434
 http://purl.obolibrary.org/obo/MONDO_0001442
 http://purl.obolibrary.org/obo/MONDO_0001443
 http://purl.obolibrary.org/obo/MONDO_0001458
+http://purl.obolibrary.org/obo/MONDO_0001461
 http://purl.obolibrary.org/obo/MONDO_0001464
 http://purl.obolibrary.org/obo/MONDO_0001468
 http://purl.obolibrary.org/obo/MONDO_0001476
@@ -3262,7 +3265,6 @@ http://purl.obolibrary.org/obo/MONDO_0008544
 http://purl.obolibrary.org/obo/MONDO_0008546
 http://purl.obolibrary.org/obo/MONDO_0008547
 http://purl.obolibrary.org/obo/MONDO_0008549
-http://purl.obolibrary.org/obo/MONDO_0979242
 http://purl.obolibrary.org/obo/MONDO_0008551
 http://purl.obolibrary.org/obo/MONDO_0008553
 http://purl.obolibrary.org/obo/MONDO_0008554
@@ -5419,6 +5421,7 @@ http://purl.obolibrary.org/obo/MONDO_0012335
 http://purl.obolibrary.org/obo/MONDO_0012341
 http://purl.obolibrary.org/obo/MONDO_0012342
 http://purl.obolibrary.org/obo/MONDO_0012345
+http://purl.obolibrary.org/obo/MONDO_0012350
 http://purl.obolibrary.org/obo/MONDO_0012351
 http://purl.obolibrary.org/obo/MONDO_0012353
 http://purl.obolibrary.org/obo/MONDO_0012354
@@ -6403,6 +6406,7 @@ http://purl.obolibrary.org/obo/MONDO_0014333
 http://purl.obolibrary.org/obo/MONDO_0014334
 http://purl.obolibrary.org/obo/MONDO_0014335
 http://purl.obolibrary.org/obo/MONDO_0014336
+http://purl.obolibrary.org/obo/MONDO_0014337
 http://purl.obolibrary.org/obo/MONDO_0014339
 http://purl.obolibrary.org/obo/MONDO_0014342
 http://purl.obolibrary.org/obo/MONDO_0014343
@@ -11448,6 +11452,7 @@ http://purl.obolibrary.org/obo/MONDO_0700298
 http://purl.obolibrary.org/obo/MONDO_0700299
 http://purl.obolibrary.org/obo/MONDO_0700300
 http://purl.obolibrary.org/obo/MONDO_0700301
+http://purl.obolibrary.org/obo/MONDO_0700325
 http://purl.obolibrary.org/obo/MONDO_0700335
 http://purl.obolibrary.org/obo/MONDO_0700338
 http://purl.obolibrary.org/obo/MONDO_0700341
@@ -12239,6 +12244,7 @@ http://purl.obolibrary.org/obo/MONDO_0979238
 http://purl.obolibrary.org/obo/MONDO_0979239
 http://purl.obolibrary.org/obo/MONDO_0979240
 http://purl.obolibrary.org/obo/MONDO_0979241
+http://purl.obolibrary.org/obo/MONDO_0979242
 http://purl.obolibrary.org/obo/MONDO_0979243
 http://purl.obolibrary.org/obo/MONDO_0979245
 http://purl.obolibrary.org/obo/MONDO_0979246
@@ -12285,14 +12291,9 @@ http://purl.obolibrary.org/obo/MONDO_1060152
 http://purl.obolibrary.org/obo/MONDO_1060177
 http://purl.obolibrary.org/obo/MONDO_1060179
 http://purl.obolibrary.org/obo/MONDO_1060185
+http://purl.obolibrary.org/obo/MONDO_1060213
 http://purl.obolibrary.org/obo/MONDO_8000000
 http://purl.obolibrary.org/obo/MONDO_8000006
 http://purl.obolibrary.org/obo/MONDO_8000010
 http://purl.obolibrary.org/obo/MONDO_8000011
 http://purl.obolibrary.org/obo/MONDO_8000012
-http://purl.obolibrary.org/obo/MONDO_0700325
-http://purl.obolibrary.org/obo/MONDO_0014337
-http://purl.obolibrary.org/obo/MONDO_1060213
-http://purl.obolibrary.org/obo/MONDO_0001461
-http://purl.obolibrary.org/obo/MONDO_0000245
-http://purl.obolibrary.org/obo/MONDO_0001405

--- a/src/ontology/reports/mondo_obsolete_import_check.tsv
+++ b/src/ontology/reports/mondo_obsolete_import_check.tsv
@@ -200,6 +200,7 @@ http://purl.obolibrary.org/obo/MONDO_0016021	http://purl.obolibrary.org/obo/MOND
 http://purl.obolibrary.org/obo/MONDO_0016022	http://purl.obolibrary.org/obo/MONDO_0800491	OK
 http://purl.obolibrary.org/obo/MONDO_0016025	http://purl.obolibrary.org/obo/MONDO_0014633	OK
 http://purl.obolibrary.org/obo/MONDO_0016054		NO_REPLACEMENT
+http://purl.obolibrary.org/obo/MONDO_0016061	http://purl.obolibrary.org/obo/MONDO_0012350	OK
 http://purl.obolibrary.org/obo/MONDO_0016072		NO_REPLACEMENT
 http://purl.obolibrary.org/obo/MONDO_0016109		NO_REPLACEMENT
 http://purl.obolibrary.org/obo/MONDO_0016110		NO_REPLACEMENT


### PR DESCRIPTION
## Summary
Fixes two CI failures, both caused by the latest `mondo-base.owl` mirror (upstream MONDO changes, not EFO-authored). CI fetches a fresh MONDO mirror and regenerates `imports/mondo_import.owl`, so both surface on `master` too.

### 1. `nolabels-violation` — 9 unlabeled GO/NCBITaxon fillers
The latest MONDO declares 9 foreign terms (3 GO, 6 NCBITaxon) as bare, **label-less** `owl:Class` and uses them as `someValuesFrom` fillers in disease axioms. The BOT extract pulls them into the MONDO import without labels → 9 classes with no `rdfs:label` in the merged/reasoned `build/efo.owl`.
**Fix:** add the 9 IRIs to `iri_dependencies/mondo_exclude.txt` (the same mechanism that already auto-strips HGNC fillers).

### 2. `check_mondo_obsoletes` — deprecated import with missing replacement
We import `MONDO_0016061` ("immunodeficiency with factor H anomaly"), which the latest MONDO deprecated, replacing it with `MONDO_0012350` ("complement factor H deficiency"). The QC gate requires a deprecated import's replacement to also be in the term list.
**Fix:** add `MONDO_0012350` to `iri_dependencies/mondo_terms.txt` (re-sorts the file; no terms lost). Additionally, the obsolete EFO term `Orphanet_200421` had its `IAO_0100001`/`reason_for_obsolescence` pointing at the now-obsolete `MONDO_0016061` — repointed forward to the live `MONDO_0012350`.

## Changes
| Action | File | Detail |
|--------|------|--------|
| Edited | `iri_dependencies/mondo_exclude.txt` | +9 IRIs: GO_0006559, GO_0006569, GO_0016592, NCBITaxon_1678143/2732541/27829/3044783/3052230/3052310 |
| Edited | `iri_dependencies/mondo_terms.txt` | +MONDO_0012350 (file re-sorted; net +1 line) |
| Edited | `efo-edit.owl` | Orphanet_200421 replaced-by MONDO_0016061 → MONDO_0012350 (2 lines) |
| Regenerated | `imports/mondo_terms.txt`, `reports/mondo_obsolete_import_check.tsv` | tracked artifacts refreshed |

## Checks
- [x] `nolabels`: full reasoned `build/efo.owl` → **PASS, 0 violations**; regenerating the MONDO import after adding MONDO_0012350 introduced no new unlabeled classes (differential diff empty)
- [x] `check_mondo_obsoletes`: **0 missing replacements, exit 0**; MONDO_0012350 imported with label
- [x] 9 prior exclusions still absent from regenerated import
- [x] `efo-edit.owl`: MONDO_0016061 → 0 occurrences; MONDO_0012350 → 2; `normalize_src` clean; metadata-only change on an already-deprecated term (no satisfiability impact)

## Notes
- Pre-existing, unrelated to this PR: 11 PATO dangling-reference build warnings; 473 deprecated MONDO imports with no upstream replacement defined (warning-only in `check_mondo_obsoletes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)