### PR TITLE
Restore the HGNC echo's pipeline-relative path

### DIFF
--- a/owlmake.yaml
+++ b/owlmake.yaml
@@ -37,7 +37,7 @@ imports:
         filename: src/ontology/imports/mondo_import.owl.hgnc.txt
       then:
       - op: shell
-        command: echo "Auto-excluding $(wc -l < src/ontology/imports/mondo_import.owl.hgnc.txt | tr -d ' ') HGNC terms from mondo import"
+        command: echo "Auto-excluding $(wc -l < imports/mondo_import.owl.hgnc.txt | tr -d ' ') HGNC terms from mondo import"
       - op: append
         src:
         - src/ontology/imports/mondo_import.owl.hgnc.txt
@@ -640,7 +640,7 @@ prerequisites:
         filename: src/ontology/imports/mondo_import.owl.hgnc.txt
       then:
       - op: shell
-        command: echo "Auto-excluding $(wc -l < src/ontology/imports/mondo_import.owl.hgnc.txt | tr -d ' ') HGNC terms from mondo import"
+        command: echo "Auto-excluding $(wc -l < imports/mondo_import.owl.hgnc.txt | tr -d ' ') HGNC terms from mondo import"
       - op: append
         src:
         - src/ontology/imports/mondo_import.owl.hgnc.txt


### PR DESCRIPTION
One-commit follow-up to fold into `owlmake-migration` (merged immediately, same flow as before). The earlier review-fix rewrote the HGNC auto-exclude echo's `wc` path to the repo-root spelling; import-pipeline shell steps actually run from `src/ontology` and command-substitution text reaches the shell verbatim, so the rewrite emptied the count — visible in CI run 32986716429 as `sh: can't open src/ontology/imports/mondo_import.owl.hgnc.txt`. Restored to the original `imports/mondo_import.owl.hgnc.txt`; measured locally with om 0.2.2: `Auto-excluding 3606 HGNC terms from mondo import`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMkT6NpLSiwerUD773q8V1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMkT6NpLSiwerUD773q8V1)_