### PR TITLE
Remove legacy EFO_URI annotation (#1893)

### DIFF
--- a/src/ontology/components/efo_terms.txt
+++ b/src/ontology/components/efo_terms.txt
@@ -10416,5 +10416,4 @@ http://www.ebi.ac.uk/efo/EFO_1002048
 http://www.ebi.ac.uk/efo/EFO_1002049
 http://www.ebi.ac.uk/efo/EFO_1002050
 http://www.ebi.ac.uk/efo/EFO_1002051
-http://www.ebi.ac.uk/efo/EFO_URI
 term


### PR DESCRIPTION
## Summary

Removes the legacy `efo:EFO_URI` annotation from EFO entirely, per the audit on #1893.

`EFO_URI` is a relic of the era when EFO minted its own URIs for external terms (UO units, OBI processes, RO/BFO relations) and recorded the retired EFO URI on the replacement term. An audit of every value found that **all of them are dead**:

- 137 annotation assertions existed: 121 on classes (76 UO, 27 OBI, 8 BFO, 6 NCBITaxon, 2 IAO, 1 UBERON, 1 EFO) and 16 on object properties.
- All 137 values were distinct. 123 were `EFO_nnnnnnn` class IRIs — **none exist in `efo-edit.owl`** (active or obsolete) or anywhere else under `src/`, and spot checks return 404 in OLS4. Of the 14 legacy EFO-2.x property IRIs, 13 likewise dangle; the only resolving one was `efo:has_flag` annotating itself with its own IRI.
- Nothing generates, filters or consumes the annotation: zero references in `owlmake.yaml`, `src/sparql/`, `src/scripts/`, `.github/` and `docs/`.

This is what surfaced externally as EBISPOT/OLS#657.

## Changes

| Action | What | Where |
|--------|------|-------|
| Removed | 137 `<efo:EFO_URI>` annotation assertions | `src/ontology/efo-edit.owl` |
| Removed | `owl:AnnotationProperty` declaration for `EFO_URI` and its comment block | `src/ontology/efo-edit.owl` |
| Removed | the `EFO_URI` IRI entry | `src/ontology/components/efo_terms.txt` |

No classes, properties or other annotations were touched. `grep -rn 'EFO_URI' src/` now returns nothing (outside the generated qc diff, which refreshes on the next build).

The only non-`EFO_URI` line in the diff is an empty `<owl:Class rdf:about=".../UBERON_0014892"></owl:Class>` collapsed to self-closing form by `normalize_src` — semantically identical.

## Note for maintainers (not addressed here)

`src/ontology/components/efo_terms.txt` is a generated file that is currently **~8,000 entries stale** relative to `efo-edit.owl` — regenerating it produces 8,046 additions. I deliberately did not include that regeneration, to keep this PR focused; only the single `EFO_URI` line was removed. Might be worth a separate ticket.

## Checks

- [x] `om make normalize_src` ran clean
- [x] `om reason -i src/ontology/efo-edit.owl -r ELK` — exit 0, no unsatisfiable classes; 36022 inferred axioms, unchanged from master (the "22 axioms outside OWL 2 EL ignored" note is pre-existing and unrelated: annotations are not logical axioms)
- [x] `om convert` syntax check passes
- [x] No new terms added, so no temporary `EFO_099xxxx` IDs are involved

Closes #1893

Also resolves the problem reported in #820 (same root cause — `OBI_0000070` no longer carries the dangling `EFO_0001455` link); that issue can be closed as a duplicate once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)