### PR TITLE
docs: forbid concurrent subagent dispatch and subagent git reverts

### DIFF
--- a/.claude/agents/efo-curator.md
+++ b/.claude/agents/efo-curator.md
@@ -69,3 +69,4 @@ Conclude with one of:
 - Minimum **2 PMIDs** for new terms — if you can't reach 2, say so; do not pad with irrelevant citations.
 - Never guess PMIDs or ontology IDs. Verify OLS IDs with a second query (label/synonym must match).
 - Be explicit about confidence and flag anything uncertain.
+- **Never run `git checkout`, `git restore`, `git stash`, `git reset`, or any other command that discards or rewrites changes.** If you find a diff you did not make, leave it in place and report it to the orchestrator — it may be another step's work.

--- a/.claude/agents/efo-importer.md
+++ b/.claude/agents/efo-importer.md
@@ -65,3 +65,5 @@ Return to the orchestrator:
 - One IRI per line; check duplicates first.
 - Do not add RO terms to `efo-relations.txt`.
 - If a term isn't in the expected ontology, search related ones and report what you found; don't invent an IRI.
+- **Never run `git checkout`, `git restore`, `git stash`, `git reset`, or any other command that discards or rewrites changes.** If you find a diff you did not make, leave it in place and report it to the orchestrator — it may be another step's work.
+- Regenerating an import can touch files beyond `imports/` (e.g. `iri_dependencies/*_exclude.txt`, `reports/`). Report every file that changed; do not undo any of it.

--- a/.claude/agents/efo-ontologist.md
+++ b/.claude/agents/efo-ontologist.md
@@ -101,3 +101,5 @@ INTEGRATION COMPLETE
 - Flags for PR: <e.g. missing has_disease_location — note for reviewer>
 ```
 Report flags (e.g. a measurement with no clear `is_about`, or a disease missing `has_disease_location`) rather than guessing — the orchestrator will surface them in the PR. Do not commit or push.
+
+- **Never run `git checkout`, `git restore`, `git stash`, `git reset`, or any other command that discards or rewrites changes.** If you find a diff you did not make, leave it in place and report it to the orchestrator — it may be another step's work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ This is a multi-agent system. **You are the orchestrator** — the only one who 
 
 - **Subagents cannot call other subagents.** All routing and sequencing is your job. Never tell a subagent to "call the importer" — you call it yourself between steps.
 - **Subagents are stateless and return one final message.** Pass them complete context up front (see Handoff template below). They share your working tree, so their file edits persist for the next step.
+- **Never run two subagents concurrently in the same working tree, even if they edit different files.** `om make` targets (especially `--rebuild`) rewrite files across the tree, and a subagent that sees an unexpected diff may revert it — wiping another subagent's edit. Run them one at a time and review the diff between dispatches. The harness's general advice to parallelise independent tool calls does not apply to subagents here.
 - **Only you touch git.** Subagents edit files and run `om`; **you** create the branch, commit, and open the PR. Do not ask subagents to commit or push.
 
 ---
@@ -70,6 +71,7 @@ Current state: <what's done so far, what files already changed>
 Task: <specific, actionable request>
 Expected output: <exactly what you need back to continue>
 Dependencies: <terms that must exist first, files already updated>
+Do not touch: <files outside this step's remit; never revert anything>
 ```
 
 Example (curator):


### PR DESCRIPTION
## Summary
Instruction-only change, no ontology edits.

While folding the Mondo v2026-09-01 fix into #2777, the orchestrator dispatched `efo-importer` and `efo-ontologist` in parallel in the same working tree. The importer's `--rebuild` rewrote files across the tree, it then reverted `efo-edit.owl` with `git checkout`, and the ontologist's two-line edit was silently lost. It was caught and redone, but the instructions had two gaps:

- CLAUDE.md said "dispatch subagents in sequence" but not why, so it read as a dependency-ordering rule rather than a safety rule (and the harness generally encourages parallel independent calls).
- No subagent spec forbade discarding changes. "Only you touch git" lives in CLAUDE.md, which subagents don't read; the importer spec only said "does not commit".

## Changes
| File | Change |
|------|--------|
| `CLAUDE.md` | New constraint bullet: never run two subagents concurrently in the same tree, with the reason. Handoff template gains a `Do not touch:` line. |
| `.claude/agents/efo-curator.md` | Hard rule: never `git checkout`/`restore`/`stash`/`reset`; report unexpected diffs. |
| `.claude/agents/efo-importer.md` | Same rule, plus: regeneration touches files outside `imports/` (exclude lists, reports); report them, don't undo them. |
| `.claude/agents/efo-ontologist.md` | Same rule. |

`.github/copilot-instructions.md` already says "serial not parallel" and is unchanged.

## Checks
- [x] No changes under `src/`
- [x] Wording consistent across the three specs (identical rule text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)