### PR TITLE
Remove all self-referential xrefs and add a QC rule against them (#752)

### DIFF
--- a/owlmake.yaml
+++ b/owlmake.yaml
@@ -1272,6 +1272,7 @@ prerequisites:
     - src/sparql/deprecated-violation.sparql
     - src/sparql/obsolete-replaced-whitespace-violation.sparql
     - src/sparql/wrong_efo_purl-violation.sparql
+    - src/sparql/self-xref-violation.sparql
     - -O
     - src/ontology/reports
 - target: all_reports

--- a/src/sparql/self-xref-violation.sparql
+++ b/src/sparql/self-xref-violation.sparql
@@ -1,0 +1,19 @@
+# An entity must not carry an oboInOwl:hasDbXref to itself (EBISPOT/efo#752).
+# Matches both the CURIE form (EFO:0000768 on EFO_0000768, Orphanet:84132 on
+# ORDO/Orphanet_84132, GO:0007610 on obo/GO_0007610) and the full-IRI form.
+#
+# Scope: every owl:Class, plus any entity in the EFO namespace. Imported
+# UBERON/OBA modules still carry legacy self-xrefs on a handful of RO/BFO
+# object properties (e.g. RO:0002353 on RO_0002353); those are upstream's and
+# reappear on every import refresh, so foreign properties are deliberately
+# excluded here. efo-edit.owl itself carries none since #752 was fixed.
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix oio: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT ?entity ?xref WHERE {
+  ?entity oio:hasDbXref ?xref .
+  FILTER(isIRI(?entity))
+  FILTER(EXISTS { ?entity a owl:Class } || STRSTARTS(STR(?entity), "http://www.ebi.ac.uk/efo/"))
+  BIND(REPLACE(REPLACE(STR(?entity), "^(http://www.ebi.ac.uk/efo/|http://purl.obolibrary.org/obo/|http://www.orpha.net/ORDO/)", ""), "_", ":") AS ?curie)
+  FILTER(LCASE(STR(?xref)) = LCASE(?curie) || LCASE(STR(?xref)) = LCASE(STR(?entity)))
+}


### PR DESCRIPTION
## Summary
Closes the 2020 request to drop `hasDbXref` annotations whose value is the annotated entity itself. They carry no information, and the count had grown from 265 (2021) to 1,138. Rather than filter them at release time (the approach of the closed #1665), this removes them from the edit file and adds a QC rule so they cannot come back.

| Where | Removed | Detail |
|-------|---------|--------|
| Classes | 1,046 direct xrefs | 840 on obsolete terms (MONDO-style xref sets that included the term's own ID), 12 on active native EFO terms, 194 on foreign classes asserted in the edit file (FBbt, Orphanet, ZFA, PO, FMA, GO, DOID…) |
| Classes | 869 reified `owl:Axiom` blocks | the annotation axioms on those self-xrefs (`oboInOwl:source MONDO:equivalentTo`) |
| Properties and undeclared IRIs | 92 direct xrefs | RO 39, BSPO 25, UBPROP 8, BFO 7, SIO 3, UBREL 2, FMA 2, GO 4, `dc:creator`, `rdfs:seeAlso` — legacy UBERON/FBbt import residue |

## Changes
- `src/ontology/efo-edit.owl`: the removals above, nothing else. Seven foreign classes (`FBbt_00005566`, `FBbt_00005670`, `FBbt_00007049`, `GO_0010960`, `GO_0042747`, `GO_0042748`, `HP_0000708`) had the self-xref as their only content, so normalize collapses their stanzas to bare declarations; they are still declared and still referenced.
- `src/sparql/self-xref-violation.sparql` (new) + `owlmake.yaml`: registered in `sparql_test`. Scoped to `owl:Class` plus any EFO-namespace entity, because the UBERON/OBA modules still ship 11 upstream self-xrefs on RO/BFO object properties (e.g. `RO:0002353` on `RO_0002353`) that would reappear on every import refresh. The rule's header comment records this.

## Verification
- Full (entity, xref) set and full reified-annotation set extracted by SPARQL from `master` and from this branch and diffed: exactly 1,138 direct pairs and 869 reified axioms removed, every one self-referential, zero additions, zero non-self removals.
- `om make qc` (what CI runs): all 12 SPARQL rules pass including the new one, `report_test` 0 errors, `check_mondo_obsoletes` clean; HermiT classifies without unsatisfiable classes as part of the build.
- Regenerated `reports/*.tsv` are not committed: the tracked copies date from 17 August and their diffs are dominated by unrelated churn.

## Notes
- The 11 import-side property self-xrefs are upstream's; if EFO wants them gone from releases too, a release-time `DELETE` as in #1665 would still be needed for those. Not done here.
- #684 (EFO→EFO cross-references between *different* terms) is a separate question and is not addressed by this PR.

## Checks
- [x] No new terms, no imports touched — curator/importer steps and temporary-ID handling N/A
- [x] `om make normalize_src` clean; `om make qc` green locally
- [x] Semantic before/after audit above

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)