### PR TITLE
Fix definitive-ID allocation: build the gitignored MONDO import first

### DIFF
--- a/.github/workflows/allocate-definitive-ids.yml
+++ b/.github/workflows/allocate-definitive-ids.yml
@@ -41,15 +41,40 @@ jobs:
             echo "has_temp=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # mondo_import.owl is gitignored (~150 MB, past GitHub's file size limit)
+      # and regenerated from the MONDO release, so it must be built before
+      # efo-edit.owl can resolve its imports — owlmake parses the edit file
+      # through catalog-v001.xml and fails outright if the module is missing.
+      # All other import modules are committed.
+      - name: Prepare MONDO import
+        if: steps.check.outputs.has_temp == 'true'
+        run: |
+          om make imports/mondo_import.owl --rebuild mirrors,imports
+
       - name: Allocate definitive IDs
         if: steps.check.outputs.has_temp == 'true'
         run: |
           om make allocate-definitive-ids
 
+      # Pushed inline rather than via actions-js/push: that action's entrypoint
+      # spawns `bash`, which the owlmake image does not ship (every other step
+      # here runs under `sh`). Checkout used persist-credentials: false, so the
+      # token is supplied on the push URL. Only efo-edit.owl is staged — the
+      # regenerated MONDO import and mirror are gitignored, and staging the one
+      # file we changed keeps build artifacts out of the commit.
       - name: Commit and push changes
         if: steps.check.outputs.has_temp == 'true'
-        uses: actions-js/push@v1.5
-        with:
-          github_token: ${{ secrets.EFO_ID_ALLOCATION_TOKEN }}
-          message: "Replace temporary IDs by definitive IDs."
-          branch: ${{ github.ref }}
+        env:
+          GH_TOKEN: ${{ secrets.EFO_ID_ALLOCATION_TOKEN }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/ontology/efo-edit.owl
+          if git diff --cached --quiet; then
+            echo "Allocation produced no change to efo-edit.owl; nothing to push."
+            exit 0
+          fi
+          git commit -m "Replace temporary IDs by definitive IDs."
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:${GITHUB_REF}"


### PR DESCRIPTION
## Summary

`Allocate definitive EFO IDs` failed on the first run that actually had temporary IDs to allocate ([run 33666866302](https://github.com/EBISPOT/efo/actions/runs/33666866302/job/100370669446)):

```
building allocate-definitive-ids: `owl:imports <http://www.ebi.ac.uk/efo/imports/mondo_import.owl>`
maps to /__w/efo/efo/src/ontology/imports/mondo_import.owl in the catalog, which does not exist
```

`efo-edit.owl` declares 23 `owl:imports` resolved through `catalog-v001.xml`. Every module is committed **except** `imports/mondo_import.owl`, which is ~150 MB (past GitHub's file-size limit) and gitignored (`.gitignore:89`), so it is absent from a fresh CI checkout and `om make` refuses to build the target.

Every earlier green run of this workflow hit `has_temp=false` and skipped allocation, so this path had never executed on `master` — the missing step was not a regression, it was never exercised.

## Changes

- **`Prepare MONDO import` step** — `om make imports/mondo_import.owl --rebuild mirrors,imports` runs before allocation, under the same `has_temp` guard. ~1–2 min (240 MB mondo-base download + BOT extract). Its outputs are gitignored, so nothing extra reaches the commit.
- **Inline push** instead of `actions-js/push` — that action's `start.js` spawns `bash`, which the owlmake image does not ship (GitHub runs every other step in this job under `sh -e {0}`). The inline step stages only `efo-edit.owl`, no-ops when allocation changed nothing, and supplies the token on the push URL (checkout uses `persist-credentials: false`).

Both changes already existed on the stale local branch `EFO_ID_allocation` and were never merged; that branch also reverts since-merged work, so only the workflow file was carried over onto a fresh branch off `master`.

## Verification

Reproduced and fixed against a clean worktree of `origin/master`:

- without the prepare step → the exact CI error, before any minting;
- with it → `mint: allocated 2 definitive ID(s) from 'Automation' [920000..=929999]`, and `efo-edit.owl` changes by **11 insertions / 11 deletions** — only `EFO_0990001` → `EFO_0920136` and `EFO_0990002` → `EFO_0920137` and their referring axioms.

Note on why the import must genuinely be present: `om mint` invoked directly does *not* fail on the missing module — it silently emits **21,262 inserted lines** of spurious declarations for entities it can no longer see in the import closure. `om make`'s hard failure is a guard, so bypassing the check would have been the wrong fix.

## Notes / open questions

⚠️ **The push step is still unproven.** When this ran on `test/id-allocation` ([run 33623046310](https://github.com/EBISPOT/efo/actions/runs/33623046310)) allocation succeeded and the push failed with `remote: Permission to EBISPOT/efo.git denied to ar-ibrahim` (403) — `secrets.EFO_ID_ALLOCATION_TOKEN` appears to lack write access on `EBISPOT/efo`. Worth confirming the secret before the next `EFO_099xxxx` term reaches `master`. Alternative: `GITHUB_TOKEN` with `permissions: contents: write`, at the cost of the allocation commit not triggering the QC workflow.

The two test terms from #2786 still carry `EFO_0990001` / `EFO_0990002` on `master`; the next push to `efo-edit.owl` after this merges will allocate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GZuPariXiZvNVyPtVBXBY