### PR TITLE
fix: allocate-definitive-ids builds the MONDO import module it reads

### DIFF
--- a/owlmake.yaml
+++ b/owlmake.yaml
@@ -1419,6 +1419,7 @@ prerequisites:
   input: src/ontology/efo-edit.owl
   needs:
   - src/ontology/efo-edit.owl
+  - src/ontology/imports/mondo_import.owl
   steps:
   - op: mint
     temp_id_prefix: http://www.ebi.ac.uk/efo/EFO_099


### PR DESCRIPTION
## Summary
The "Allocate definitive EFO IDs" workflow failed on the merge of #2786 (the first time the owlmake target actually ran with temporary IDs present):

```
`owl:imports <http://www.ebi.ac.uk/efo/imports/mondo_import.owl>` maps to
src/ontology/imports/mondo_import.owl in the catalog, which does not exist
```

`mondo_import.owl` is gitignored, so a fresh checkout does not have it, and `allocate-definitive-ids` declared only `efo-edit.owl` as a prerequisite. The mint step loads the import closure so the reserialised edit file does not gain declaration stubs for every referenced imported class, so the module is a real input of the target.

## Change
Adds `src/ontology/imports/mondo_import.owl` to the target's `needs` in `owlmake.yaml`, so the plan builds it from the MONDO mirror before minting. No other import module is gitignored.

## Verification
Ran `om make allocate-definitive-ids` locally with `mondo_import.owl` moved aside: the plan rebuilt the module, then allocated the two test terms (`EFO_0990001` → `EFO_0920136`, `EFO_0990002` → `EFO_0920137`) changing 22 lines of `efo-edit.owl` and nothing else. The local edit file was restored afterwards; the allocation itself should happen on master via the workflow.

## After merge
This PR does not touch `efo-edit.owl`, so the workflow's path filter will not fire on the merge; I will dispatch it manually and confirm the two test terms get definitive IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)