### PR TITLE
fix: commit allocated IDs with plain git; the owlmake image has no bash

### DIFF
--- a/.github/workflows/allocate-definitive-ids.yml
+++ b/.github/workflows/allocate-definitive-ids.yml
@@ -46,10 +46,17 @@ jobs:
         run: |
           om make allocate-definitive-ids
 
+      # Plain git in `sh`: the owlmake image is Alpine with git but no bash, and
+      # `actions-js/push` starts with `bash start.sh`, which fails with ENOENT
+      # inside a container job on this image. Only the edit file is added — the
+      # MONDO module and mirror the allocation built are gitignored.
       - name: Commit and push changes
         if: steps.check.outputs.has_temp == 'true'
-        uses: actions-js/push@v1.5
-        with:
-          github_token: ${{ secrets.EFO_ID_ALLOCATION_TOKEN }}
-          message: "Replace temporary IDs by definitive IDs."
-          branch: ${{ github.ref }}
+        env:
+          TOKEN: ${{ secrets.EFO_ID_ALLOCATION_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/ontology/efo-edit.owl
+          git commit -m "Replace temporary IDs by definitive IDs."
+          git push "https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Summary
Follow-up to #2789. With the MONDO module now built, the dispatched "Allocate definitive EFO IDs" run on master got through minting (`mint: allocated 2 definitive ID(s)`) and then failed in the commit step:

```
Started: bash /__w/_actions/actions-js/push/v1.5/start.sh
Error: spawn bash ENOENT
```

The job runs inside `ghcr.io/ebispot/owlmake:latest-python`, which is Alpine with `git` and `sh` but no `bash`, so `actions-js/push` can never start there.

## Change
Replaces the action with the equivalent git commands in an `sh` step: configure the bot identity, add `src/ontology/efo-edit.owl`, commit "Replace temporary IDs by definitive IDs.", and push to the triggering branch with the existing `EFO_ID_ALLOCATION_TOKEN`. Only the edit file is added; the module and mirror the allocation builds are gitignored.

## After merge
I will dispatch the workflow on master again and confirm the two `EFO_099` test terms from #2786 receive definitive IDs and the trailing run takes the no-op branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)