### PR TITLE
docs: tell the agents to reason with HermiT, not ELK

### DIFF
--- a/.claude/agents/efo-ontologist.md
+++ b/.claude/agents/efo-ontologist.md
@@ -86,7 +86,7 @@ Locate by ID/label, change label/def/synonyms/relationships following patterns, 
 ```bash
 om make normalize_src
 om convert -vvv -i src/ontology/efo-edit.owl -o /dev/null   # if syntax looks off
-om reason -i src/ontology/efo-edit.owl -r ELK               # catch unsatisfiable classes
+om reason -i src/ontology/efo-edit.owl -r hermit            # catch unsatisfiable classes (HermiT — what the release build uses; ELK misses non-EL axioms)
 ```
 Checklist: label + def + ≥2 xrefs + non-obsolete parent on every new term · synonyms with a known source carry a `hasDbXref` provenance axiom · logical def mirrors text · no deprecated parents · cross-ontology links in `subclasses.csv` only when needed · normalization clean.
 

--- a/.claude/commands/efo-ticket.md
+++ b/.claude/commands/efo-ticket.md
@@ -22,7 +22,7 @@ Work through these steps, tracking them with a todo list:
    - `efo-importer` for ANY external term (never import yourself)
    - `efo-ontologist` to edit `efo-edit.owl`
    Review each report; re-dispatch with specific feedback if incomplete. Enforce: ≥2 PMIDs per new term, typed synonyms, non-obsolete verified parents.
-6. **Verify** from the repository root: `om make normalize_src`, and `om reason -i src/ontology/efo-edit.owl -r ELK`. Fix or report failures honestly.
+6. **Verify** from the repository root: `om make normalize_src`, and `om reason -i src/ontology/efo-edit.owl -r hermit`. Fix or report failures honestly.
 7. **Commit & open the PR** yourself (subagents never touch git):
    - `git add -A && git commit -m "<action>: <desc> (refs #$1)"`
    - `git push -u origin issue-$1`

--- a/.github/agents/EFO-ontologist.md
+++ b/.github/agents/EFO-ontologist.md
@@ -347,7 +347,7 @@ om make normalize_src
 To check for errors:
 ```bash
 om convert -vvv -i src/ontology/efo-edit.owl -o /dev/null
-om reason -i src/ontology/efo-edit.owl -r ELK
+om reason -i src/ontology/efo-edit.owl -r hermit
 ```
 
 ## Domain-Specific Requirements

--- a/docs/agents-documentation/efo-pr-review-checklist.md
+++ b/docs/agents-documentation/efo-pr-review-checklist.md
@@ -127,7 +127,7 @@ OWL construct reference: definition = `obo:IAO_0000115`; xref =
 ### 7. Build & config regressions
 - If the diff should have been normalized, confirm it looks like `om make
   normalize_src` was run (consistent formatting) and no unsatisfiable classes
-  were introduced (`om reason -i src/ontology/efo-edit.owl -r ELK`, if
+  were introduced (`om reason -i src/ontology/efo-edit.owl -r hermit`, if
   runnable). Flag if the diff looks un-normalized.
 - When the diff touches `.github/` or `.claude/`, check for CI, auth, permissions,
   or workflow regressions.

--- a/src/ontology/README-editors.md
+++ b/src/ontology/README-editors.md
@@ -8,7 +8,7 @@ After editing `src/ontology/efo-edit.owl`, normalize and reason over it:
 
 ```bash
 om make normalize_src
-om reason -i src/ontology/efo-edit.owl -r ELK
+om reason -i src/ontology/efo-edit.owl -r hermit
 ```
 
 Run the ontology quality checks with:


### PR DESCRIPTION
## Summary

`owlmake.yaml` already classifies every release artefact and the reasoned QC diffs with `hermit`, and `CLAUDE.md` was brought in line, but **five agent-facing docs still prescribed `om reason ... -r ELK`**. Agents follow the docs, so verification and review runs kept using ELK — including the review on #2784, which follows the canonical review checklist.

ELK is an EL reasoner: it silently ignores the non-EL axioms EFO contains, so a clean ELK run is not evidence that the release build will classify. This aligns all five with the release reasoner.

No ontology content changes — docs and agent specs only.

## Changes

| File | What it drives |
|------|----------------|
| `.claude/agents/efo-ontologist.md` | Claude ontologist subagent verification step |
| `.claude/commands/efo-ticket.md` | `/efo-ticket` verification step |
| `docs/agents-documentation/efo-pr-review-checklist.md` | canonical review checklist — shared by the Claude, Copilot and Codex reviewers |
| `.github/agents/EFO-ontologist.md` | Copilot ontologist agent |
| `src/ontology/README-editors.md` | human editor workflow |

Already correct before this PR, left untouched: `owlmake.yaml` (`reasoner: hermit` plan default, plus `hermit` pinned on `build/efo.owl` and both reasoned-diff targets) and `CLAUDE.md`.

## Checks

- [x] `om reason -i src/ontology/efo-edit.owl -r hermit` — classified 94162 classes in ~1m15s, 35838 inferred axioms asserted, **no unsatisfiable classes**
- [x] No changes to `efo-edit.owl` or any generated import, so no normalization needed
- [x] Every remaining `ELK` mention in the repo is explanatory prose contrasting it with HermiT

## Notes

Runtime is the one trade-off worth naming: HermiT takes ~1m15s where ELK is near-instant. That is the cost of checking against the reasoner that actually gates the release, and it matches what `om make` already does for the release artefact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)