### PR TITLE
[EFO 4] fix: single head-or-neck equivalence for head and neck disorder (refs #2794)

### DIFF
--- a/src/ontology/components/efo_equivalent_class_axioms.owl
+++ b/src/ontology/components/efo_equivalent_class_axioms.owl
@@ -224,8 +224,7 @@ EquivalentClasses(obo:MONDO_0005039 ObjectSomeValuesFrom(efo:EFO_0000784 obo:UBE
 
 # Class: efo:EFO_0000524 (head and neck disorder)
 
-EquivalentClasses(efo:EFO_0000524 ObjectSomeValuesFrom(efo:EFO_0000784 obo:UBERON_0000033))
-EquivalentClasses(efo:EFO_0000524 ObjectSomeValuesFrom(efo:EFO_0000784 obo:UBERON_0000974))
+EquivalentClasses(efo:EFO_0000524 ObjectSomeValuesFrom(efo:EFO_0000784 ObjectUnionOf(obo:UBERON_0000033 obo:UBERON_0000974)))
 
 # Class: efo:EFO_0000989 (root structure)
 

--- a/src/sparql/non-el-class-expression-violation.sparql
+++ b/src/sparql/non-el-class-expression-violation.sparql
@@ -187,6 +187,7 @@ WHERE {
     efo:EFO_1001914    # radiation-induced gastrointestinal mucositis [unionOf; efo-edit]
     obo:MONDO_0005275  #  [unionOf; component]
     obo:MONDO_0005554  #  [unionOf; component]
+    efo:EFO_0000524    # head and neck disorder [unionOf of two named locations; component] — replaces two conflicting equivalences, see EBISPOT/efo#2794
     }
   }
 }


### PR DESCRIPTION
## Why this PR exists: EFO is changing reasoner

EFO's release is moving from **HermiT to ELK** (#2792 → #2793). To keep location-based groupings working without unions, the switch added the property chain `has_disease_location o part_of ⊑ has_disease_location` ("located in a part of X means located in X"). That correctly classified ten more diseases — epistaxis, nasal septal perforation, orbital plasma cell granuloma, myringosclerosis and others — under `head and neck disorder`.

That exposed a latent fault in the grouping itself: `head and neck disorder` had **two** separate equivalence axioms, one over `head` and one over `neck`. Two equivalences on one class make the two fillers equivalent to each other, so every disease located in the head is entailed to be located in the neck and vice versa. It was always wrong, but with the chain now feeding many more diseases into the grouping, the false entailment reaches all of them and will surface in any consumer that follows `has_disease_location` closures. (The 2017 issue #55 had already questioned this term's modelling.) This PR fixes the grouping so the ELK release does not carry the bad entailment.

## Summary

Re-creation of #2797 (closed unmerged) against `efo-4` instead of `master`. The commit is cherry-picked unchanged; only the base branch differs.

`head and neck disorder` (EFO_0000524) carried two `EquivalentClasses` axioms in `src/ontology/components/efo_equivalent_class_axioms.owl`, one over `has_disease_location some head` and one over `has_disease_location some neck`. Two equivalences on one class make the two fillers equivalent to each other, so the ontology entailed that every disease located in the head is located in the neck and vice versa (#2794).

This PR replaces them with a single equivalence over the union of the two named locations, the same shape `rheumatic disorder` (MONDO_0005554) already uses in the same file:

```
EquivalentClasses(efo:EFO_0000524 ObjectSomeValuesFrom(efo:EFO_0000784 ObjectUnionOf(obo:UBERON_0000033 obo:UBERON_0000974)))
```

A union of **named** classes on the right-hand side of an equivalence reduces to two `SubClassOf` GCIs for the classification direction, which ELK handles, so every class that was classified under `head and neck disorder` before (including the 10 chain-derived ones from #2793) still is. Only the spurious head ≡ neck entailment goes away. The class is added to the allowlist in `src/sparql/non-el-class-expression-violation.sparql` with a documented reason, alongside the two existing named-location unions.

UBERON's `craniocervical region` (UBERON_0007811) was considered as a single EL-friendly filler, but UBERON asserts only `head part_of craniocervical region`, not `neck`, so it would drop the neck-located diseases.

## Changes
| Action | Term | EFO ID | Parent | Source ontology |
|--------|------|--------|--------|-----------------|
| Edited | head and neck disorder | EFO_0000524 | unchanged | — |

## Checks (re-run on this branch, on top of `efo-4`)
- [x] Cherry-pick applied cleanly onto `efo-4`
- [x] `om make normalize_src` clean (component file untouched by normalization)
- [x] `om reason -i src/ontology/efo-edit.owl -r elk`: no unsatisfiable classes (22 non-EL axioms ignored, as before)
- [x] `non-el-class-expression-violation.sparql` on the component and on `efo-edit.owl`: 0 violations
- [x] `has-disease-location-union-violation.sparql` on `efo-edit.owl`: 0 violations
- [x] Component round-trips (`om convert -f ofn`)
- No new terms, so no temporary IDs

## Notes / open questions
- No hierarchy change is expected in the release; the next `hermit-qc` run and the release hierarchy diff will confirm.
- A review from an OWL modelling perspective was requested on #2797 and is still welcome here.

Closes #2794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
